### PR TITLE
WIP Feature/source locations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist/
 .stack-work/
 *.class
+dist-newstyle/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ dist/
 .stack-work/
 *.class
 dist-newstyle/
+*.swp

--- a/Language/Java/Parser.hs
+++ b/Language/Java/Parser.hs
@@ -1120,11 +1120,16 @@ refType =
                             ClassRefType bs ct) <?> "refType"
 
 nonArrayType :: P (Type SourceInfo)
-nonArrayType = PrimType <$> primType <|>
-    RefType <$> ClassRefType <$> classType
+nonArrayType = withSourceSpan (PrimType <$> primType)
+    <|> withSourceSpan (RefType <$> withSourceSpan (
+        do ClassRefType <$> classType))
 
 classType :: P (ClassType SourceInfo)
-classType = ClassType <$> seplist1 classTypeSpec period
+classType = do
+  pos1 <- getPosition
+  spl <- seplist1 classTypeSpec period
+  pos2 <- getPosition
+  return $ ClassType (SourceSpan pos1 pos2) spl
 
 classTypeSpec :: P (Ident SourceInfo, [TypeArgument SourceInfo])
 classTypeSpec = do

--- a/Language/Java/Parser.hs
+++ b/Language/Java/Parser.hs
@@ -96,12 +96,15 @@ compilationUnit = do
     let srcInfo = SourceInfo pos1 pos2
     return $ CompilationUnit mpd ids (catMaybes tds) srcInfo
 
-packageDecl :: P PackageDecl
+packageDecl :: P (PackageDecl SourceInfo)
 packageDecl = do
+    pos1 <- getPosition
     tok KW_Package
     n <- name
     semiColon
-    return $ PackageDecl n
+    pos2 <- getPosition
+    let srcInfo = SourceInfo pos1 pos2
+    return $ PackageDecl n srcInfo
 
 importDecl :: P ImportDecl
 importDecl = do

--- a/Language/Java/Parser.hs
+++ b/Language/Java/Parser.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE CPP #-}
 module Language.Java.Parser (
-    parser, SourceInfo(..),
+    parser, SourceInfo(..), SourcePos(..),
 
     compilationUnit, packageDecl, importDecl, typeDecl,
 

--- a/Language/Java/Parser.hs
+++ b/Language/Java/Parser.hs
@@ -1013,55 +1013,62 @@ arrayCreation = do
     return $ f t
 
 literal :: P (Literal SourceInfo)
-literal =
+literal = do
+    srcSpot <- sourceSpot
     javaToken $ \t -> case t of
-        IntTok     i -> Just (Int i)
-        LongTok    l -> Just (Word l)
-        DoubleTok  d -> Just (Double d)
-        FloatTok   f -> Just (Float f)
-        CharTok    c -> Just (Char c)
-        StringTok  s -> Just (String s)
-        BoolTok    b -> Just (Boolean b)
-        NullTok      -> Just Null
+        IntTok     i -> Just (Int i srcSpot)
+        LongTok    l -> Just (Word l srcSpot)
+        DoubleTok  d -> Just (Double d srcSpot)
+        FloatTok   f -> Just (Float f srcSpot)
+        CharTok    c -> Just (Char c srcSpot)
+        StringTok  s -> Just (String s srcSpot)
+        BoolTok    b -> Just (Boolean b srcSpot)
+        NullTok      -> Just $ Null srcSpot
         _ -> Nothing
 
 -- Operators
 
 preIncDecOp, prefixOp, postfixOp :: P (Exp SourceInfo -> Exp SourceInfo)
 preIncDecOp =
-    (tok Op_PPlus >> return PreIncrement) <|>
-    (tok Op_MMinus >> return PreDecrement)
+  sourceSpot >>= (\srcSpot ->
+    (tok Op_PPlus >> return (PreIncrement srcSpot))<|>
+    (tok Op_MMinus >> return (PreDecrement srcSpot)))
+
 prefixOp =
-    (tok Op_Bang  >> return PreNot      ) <|>
-    (tok Op_Tilde >> return PreBitCompl ) <|>
-    (tok Op_Plus  >> return PrePlus     ) <|>
-    (tok Op_Minus >> return PreMinus    )
+  sourceSpot >>= (\srcSpot ->
+    (tok Op_Bang  >> return (PreNot srcSpot)) <|>
+    (tok Op_Tilde >> return (PreBitCompl srcSpot)) <|>
+    (tok Op_Plus  >> return (PrePlus srcSpot)) <|>
+    (tok Op_Minus >> return (PreMinus srcSpot)))
 postfixOp =
-    (tok Op_PPlus  >> return PostIncrement) <|>
-    (tok Op_MMinus >> return PostDecrement)
+  sourceSpot >>= (\srcSpot ->
+    (tok Op_PPlus  >> return (PostIncrement srcSpot)) <|>
+    (tok Op_MMinus >> return (PostDecrement srcSpot)))
 
 assignOp :: P (AssignOp SourceInfo)
 assignOp =
-    (tok Op_Equal    >> return EqualA   ) <|>
-    (tok Op_StarE    >> return MultA    ) <|>
-    (tok Op_SlashE   >> return DivA     ) <|>
-    (tok Op_PercentE >> return RemA     ) <|>
-    (tok Op_PlusE    >> return AddA     ) <|>
-    (tok Op_MinusE   >> return SubA     ) <|>
-    (tok Op_LShiftE  >> return LShiftA  ) <|>
-    (tok Op_RShiftE  >> return RShiftA  ) <|>
-    (tok Op_RRShiftE >> return RRShiftA ) <|>
-    (tok Op_AndE     >> return AndA     ) <|>
-    (tok Op_CaretE   >> return XorA     ) <|>
-    (tok Op_OrE      >> return OrA      )
+  sourceSpot >>= (\srcSpot ->
+    (tok Op_Equal    >> return (EqualA srcSpot)) <|>
+    (tok Op_StarE    >> return (MultA srcSpot)) <|>
+    (tok Op_SlashE   >> return (DivA srcSpot)) <|>
+    (tok Op_PercentE >> return (RemA srcSpot)) <|>
+    (tok Op_PlusE    >> return (AddA srcSpot)) <|>
+    (tok Op_MinusE   >> return (SubA srcSpot)) <|>
+    (tok Op_LShiftE  >> return (LShiftA srcSpot)) <|>
+    (tok Op_RShiftE  >> return (RShiftA srcSpot)) <|>
+    (tok Op_RRShiftE >> return (RRShiftA srcSpot)) <|>
+    (tok Op_AndE     >> return (AndA srcSpot)) <|>
+    (tok Op_CaretE   >> return (XorA srcSpot)) <|>
+    (tok Op_OrE      >> return (OrA srcSpot)))
 
 infixCombineOp :: P (Op SourceInfo)
 infixCombineOp =
-    (tok Op_And     >> return And       ) <|>
-    (tok Op_Caret   >> return Xor       ) <|>
-    (tok Op_Or      >> return Or        ) <|>
-    (tok Op_AAnd    >> return CAnd      ) <|>
-    (tok Op_OOr     >> return COr       )
+  sourceSpot >>= (\srcSpot ->
+    (tok Op_And     >> return (And srcSpot)) <|>
+    (tok Op_Caret   >> return (Xor srcSpot)) <|>
+    (tok Op_Or      >> return (Or srcSpot)) <|>
+    (tok Op_AAnd    >> return (CAnd srcSpot)) <|>
+    (tok Op_OOr     >> return (COr srcSpot)))
 
 
 infixOp :: P (Op SourceInfo)

--- a/Language/Java/Parser.hs
+++ b/Language/Java/Parser.hs
@@ -930,9 +930,9 @@ methodInvocationExp = try (do
     ss <- list primarySuffix
     let mip = foldl (\a s -> s a) p ss
     case mip of
-     MethodInv _ -> return mip
+     MethodInv _ e -> return mip
      _ -> fail "") <|>
-     (MethodInv <$> methodInvocationNPS)
+     withSourceSpan (MethodInv <$> methodInvocationNPS)
 
 --TODO REMOVE?
 {-

--- a/Language/Java/Pretty.hs
+++ b/Language/Java/Pretty.hs
@@ -475,14 +475,14 @@ ppArgs p = parens . hsep . punctuate comma . map (prettyPrec p)
 
 instance Pretty (Type a) where
   prettyPrec p (PrimType pt _) = prettyPrec p pt
-  prettyPrec p (RefType  rt _) = prettyPrec p rt
+  prettyPrec p (RefType rt _) = prettyPrec p rt
 
 instance Pretty (RefType a) where
   prettyPrec p (ClassRefType ct _) = prettyPrec p ct
   prettyPrec p (ArrayType t _) = prettyPrec p t <> text "[]"
 
 instance Pretty (ClassType a) where
-  prettyPrec p (ClassType itas _) =
+  prettyPrec p (ClassType _ itas) =
     hcat . punctuate (char '.') $
       map (\(i,tas) -> prettyPrec p i <> ppTypeParams p tas) itas
 

--- a/Language/Java/Pretty.hs
+++ b/Language/Java/Pretty.hs
@@ -487,8 +487,8 @@ instance Pretty (ClassType a) where
       map (\(i,tas) -> prettyPrec p i <> ppTypeParams p tas) itas
 
 instance Pretty (TypeArgument a) where
-  prettyPrec p (ActualType rt _) = prettyPrec p rt
-  prettyPrec p (Wildcard mBound _) = char '?' <+> maybePP p mBound
+  prettyPrec p (ActualType _ rt) = prettyPrec p rt
+  prettyPrec p (Wildcard _ mBound) = char '?' <+> maybePP p mBound
 
 instance Pretty (TypeDeclSpecifier a) where
   prettyPrec p (TypeDeclSpecifier ct _) = prettyPrec p ct

--- a/Language/Java/Pretty.hs
+++ b/Language/Java/Pretty.hs
@@ -499,8 +499,8 @@ instance Pretty (Diamond a) where
   prettyPrec p (Diamond _) = text "<>"
 
 instance Pretty (WildcardBound a) where
-  prettyPrec p (ExtendsBound rt _) = text "extends" <+> prettyPrec p rt
-  prettyPrec p (SuperBound   rt _) = text "super"   <+> prettyPrec p rt
+  prettyPrec p (ExtendsBound _ rt) = text "extends" <+> prettyPrec p rt
+  prettyPrec p (SuperBound   _ rt) = text "super"   <+> prettyPrec p rt
 
 instance Pretty (PrimType a) where
   prettyPrec p (BooleanT _) = text "boolean"

--- a/Language/Java/Pretty.hs
+++ b/Language/Java/Pretty.hs
@@ -31,12 +31,13 @@ class Pretty a where
 -----------------------------------------------------------------------
 -- Packages
 
+-- SourceInfo param a note: Leaving this unpretty printed for now
 instance Pretty (CompilationUnit a) where
-  prettyPrec p (CompilationUnit mpd ids tds a) =
+  prettyPrec p (CompilationUnit mpd ids tds _) =
     vcat $ ((maybePP p mpd): map (prettyPrec p) ids) ++ map (prettyPrec p) tds
 
-instance Pretty PackageDecl where
-  prettyPrec p (PackageDecl name) = text "package" <+> prettyPrec p name <> semi
+instance Pretty (PackageDecl a) where
+  prettyPrec p (PackageDecl name _) = text "package" <+> prettyPrec p name <> semi
 
 instance Pretty ImportDecl where
   prettyPrec p (ImportDecl st name wc) =

--- a/Language/Java/Pretty.hs
+++ b/Language/Java/Pretty.hs
@@ -32,15 +32,15 @@ class Pretty a where
 -- Packages
 
 -- SourceInfo param a note: Leaving this unpretty printed for now
-instance Pretty (CompilationUnit a) where
+instance Show a => Pretty (CompilationUnit a) where
   prettyPrec p (CompilationUnit mpd ids tds _) =
     vcat $ ((maybePP p mpd): map (prettyPrec p) ids) ++ map (prettyPrec p) tds
 
-instance Pretty (PackageDecl a) where
+instance Show a => Pretty (PackageDecl a) where
   prettyPrec p (PackageDecl name _) = text "package" <+> prettyPrec p name <> semi
 
-instance Pretty ImportDecl where
-  prettyPrec p (ImportDecl st name wc) =
+instance Show a => Pretty (ImportDecl a) where
+  prettyPrec p (ImportDecl st name wc a) =
     text "import" <+> opt st (text "static")
                   <+> prettyPrec p name <> opt wc (text ".*")
                   <> semi
@@ -48,19 +48,19 @@ instance Pretty ImportDecl where
 -----------------------------------------------------------------------
 -- Declarations
 
-instance Pretty TypeDecl where
-  prettyPrec p (ClassTypeDecl     cd) = prettyPrec p cd
-  prettyPrec p (InterfaceTypeDecl id) = prettyPrec p id
+instance Show a => Pretty (TypeDecl a) where
+  prettyPrec p (ClassTypeDecl     cd _) = prettyPrec p cd
+  prettyPrec p (InterfaceTypeDecl id _) = prettyPrec p id
 
-instance Pretty ClassDecl where
-  prettyPrec p (EnumDecl mods ident impls body) =
+instance Show a => Pretty (ClassDecl a) where
+  prettyPrec p (EnumDecl mods ident impls body _) =
     hsep [hsep (map (prettyPrec p) mods)
           , text "enum"
-          , prettyPrec p ident 
+          , prettyPrec p ident
           , ppImplements p impls
          ] $$ prettyPrec p body
 
-  prettyPrec p (ClassDecl mods ident tParams mSuper impls body) =
+  prettyPrec p (ClassDecl mods ident tParams mSuper impls body _) =
     hsep [hsep (map (prettyPrec p) mods)
           , text "class"
           , prettyPrec p ident
@@ -69,25 +69,25 @@ instance Pretty ClassDecl where
           , ppImplements p impls
          ] $$ prettyPrec p body
 
-instance Pretty ClassBody where
-  prettyPrec p (ClassBody ds) =
+instance Show a => Pretty (ClassBody a) where
+  prettyPrec p (ClassBody ds _) =
     braceBlock (map (prettyPrec p) ds)
-    
-instance Pretty EnumBody where
-  prettyPrec p (EnumBody cs ds) =
-    braceBlock $ 
-        punctuate comma (map (prettyPrec p) cs) ++ 
+
+instance Show a => Pretty (EnumBody a) where
+  prettyPrec p (EnumBody cs ds _) =
+    braceBlock $
+        punctuate comma (map (prettyPrec p) cs) ++
         opt (not $ null ds) semi : map (prettyPrec p) ds
 
-instance Pretty EnumConstant where
-  prettyPrec p (EnumConstant ident args mBody) =
-    prettyPrec p ident 
+instance Show a => Pretty (EnumConstant a) where
+  prettyPrec p (EnumConstant ident args mBody _) =
+    prettyPrec p ident
         -- needs special treatment since even the parens are optional
-        <> opt (not $ null args) (ppArgs p args) 
+        <> opt (not $ null args) (ppArgs p args)
       $$ maybePP p mBody
 
-instance Pretty InterfaceDecl where
-  prettyPrec p (InterfaceDecl kind mods ident tParams impls body) =
+instance Show a => Pretty (InterfaceDecl a) where
+  prettyPrec p (InterfaceDecl kind mods ident tParams impls body _) =
     hsep [hsep (map (prettyPrec p) mods)
           , text (if kind == InterfaceNormal then "interface" else "@interface")
           , prettyPrec p ident
@@ -95,20 +95,20 @@ instance Pretty InterfaceDecl where
           , ppExtends p impls
          ] $$ prettyPrec p body
 
-instance Pretty InterfaceBody where
-  prettyPrec p (InterfaceBody mds) =
+instance Show a => Pretty (InterfaceBody a) where
+  prettyPrec p (InterfaceBody mds _) =
     braceBlock (map (prettyPrec p) mds)
 
-instance Pretty Decl where
-  prettyPrec p (MemberDecl md) = prettyPrec p md
-  prettyPrec p (InitDecl b bl) =
+instance Show a => Pretty (Decl a) where
+  prettyPrec p (MemberDecl md _) = prettyPrec p md
+  prettyPrec p (InitDecl b bl _) =
     opt b (text "static") <+> prettyPrec p bl
 
-instance Pretty MemberDecl where
-  prettyPrec p (FieldDecl mods t vds) =
+instance Show a => Pretty (MemberDecl a) where
+  prettyPrec p (FieldDecl mods t vds _) =
     hsep (map (prettyPrec p) mods ++ prettyPrec p t:punctuate (text ",") (map (prettyPrec p) vds)) <> semi
 
-  prettyPrec p (MethodDecl mods tParams mt ident fParams throws def body) =
+  prettyPrec p (MethodDecl mods tParams mt ident fParams throws def body _) =
     hsep [hsep (map (prettyPrec p) mods)
           , ppTypeParams p tParams
           , ppResultType p mt
@@ -118,7 +118,7 @@ instance Pretty MemberDecl where
           , ppDefault p def
          ] $$ prettyPrec p body
 
-  prettyPrec p (ConstructorDecl mods tParams ident fParams throws body) =
+  prettyPrec p (ConstructorDecl mods tParams ident fParams throws body _) =
     hsep [hsep (map (prettyPrec p) mods)
           , ppTypeParams p tParams
           , prettyPrec p ident
@@ -126,94 +126,94 @@ instance Pretty MemberDecl where
           , ppThrows p throws
          ] $$ prettyPrec p body
 
-  prettyPrec p (MemberClassDecl cd) = prettyPrec p cd
-  prettyPrec p (MemberInterfaceDecl id) = prettyPrec p id
+  prettyPrec p (MemberClassDecl cd _) = prettyPrec p cd
+  prettyPrec p (MemberInterfaceDecl id _) = prettyPrec p id
 
-instance Pretty VarDecl where
-  prettyPrec p (VarDecl vdId Nothing) = prettyPrec p vdId
-  prettyPrec p (VarDecl vdId (Just ie)) =
+instance Show a => Pretty (VarDecl a) where
+  prettyPrec p (VarDecl vdId Nothing _) = prettyPrec p vdId
+  prettyPrec p (VarDecl vdId (Just ie) _) =
     (prettyPrec p vdId <+> char '=') <+> prettyPrec p ie
 
-instance Pretty VarDeclId where
-  prettyPrec p (VarId ident) = prettyPrec p ident
-  prettyPrec p (VarDeclArray vId) = prettyPrec p vId <> text "[]"
+instance Show a => Pretty (VarDeclId a) where
+  prettyPrec p (VarId ident _) = prettyPrec p ident
+  prettyPrec p (VarDeclArray vId _) = prettyPrec p vId <> text "[]"
 
-instance Pretty VarInit where
-  prettyPrec p (InitExp e) = prettyPrec p e
-  prettyPrec p (InitArray (ArrayInit ai)) =
+instance Show a => Pretty (VarInit a) where
+  prettyPrec p (InitExp e _) = prettyPrec p e
+  prettyPrec p (InitArray (ArrayInit ai _) _) =
     text "{" <+> hsep (punctuate comma (map (prettyPrec p) ai)) <+> text "}"
 
-instance Pretty FormalParam where
-  prettyPrec p (FormalParam mods t b vId) =
+instance Show a => Pretty (FormalParam a) where
+  prettyPrec p (FormalParam mods t b vId _) =
     hsep [hsep (map (prettyPrec p) mods)
           , prettyPrec p t <> opt b (text "...")
           , prettyPrec p vId
          ]
 
-instance Pretty MethodBody where
-  prettyPrec p (MethodBody mBlock) = maybe semi (prettyPrec p) mBlock
+instance Show a => Pretty (MethodBody a) where
+  prettyPrec p (MethodBody mBlock _) = maybe semi (prettyPrec p) mBlock
 
-instance Pretty ConstructorBody where
-  prettyPrec p (ConstructorBody mECI stmts) =
+instance Show a => Pretty (ConstructorBody a) where
+  prettyPrec p (ConstructorBody mECI stmts _) =
     braceBlock $ maybePP p mECI : map (prettyPrec p) stmts
 
-instance Pretty ExplConstrInv where
-  prettyPrec p (ThisInvoke rts args) =
+instance Show a => Pretty (ExplConstrInv a) where
+  prettyPrec p (ThisInvoke rts args _) =
     ppTypeParams p rts <+> text "this" <> ppArgs p args <> semi
-  prettyPrec p (SuperInvoke rts args) =
+  prettyPrec p (SuperInvoke rts args _) =
     ppTypeParams p rts <+> text "super" <> ppArgs p args <> semi
-  prettyPrec p (PrimarySuperInvoke e rts args) =
+  prettyPrec p (PrimarySuperInvoke e rts args _) =
     prettyPrec p e <> char '.' <>
       ppTypeParams p rts <+> text "super" <> ppArgs p args <> semi
 
-instance Pretty Modifier where
-  prettyPrec p (Annotation ann) = prettyPrec p ann $+$ nest (-1) ( text "")
+instance Show a => Pretty (Modifier a) where
+  prettyPrec p (Annotation ann _) = prettyPrec p ann $+$ nest (-1) ( text "")
   prettyPrec p mod = text . map toLower $ show mod
 
-instance Pretty Annotation where
+instance Show a => Pretty (Annotation a) where
   prettyPrec p x = text "@" <> prettyPrec p (annName x) <> case x of
          MarkerAnnotation {} -> text ""
-         SingleElementAnnotation {} -> text "(" <> prettyPrec p (annValue x) <> text ")"  
+         SingleElementAnnotation {} -> text "(" <> prettyPrec p (annValue x) <> text ")"
          NormalAnnotation {} -> text "(" <> ppEVList p (annKV x) <> text ")"
 
 ppEVList p = hsep . punctuate comma . map (\(k,v) -> prettyPrec p k <+> text "=" <+> prettyPrec p v)
 
-instance Pretty ElementValue where
-  prettyPrec p (EVVal vi) = prettyPrec p vi
-  prettyPrec p (EVAnn ann) = prettyPrec p ann
+instance Show a => Pretty (ElementValue a) where
+  prettyPrec p (EVVal vi _) = prettyPrec p vi
+  prettyPrec p (EVAnn ann _) = prettyPrec p ann
 
 -----------------------------------------------------------------------
 -- Statements
 
 
-instance Pretty Block where
-  prettyPrec p (Block stmts) = braceBlock $ map (prettyPrec p) stmts
+instance Show a => Pretty (Block a) where
+  prettyPrec p (Block stmts _) = braceBlock $ map (prettyPrec p) stmts
 
-instance Pretty BlockStmt where
-  prettyPrec p (BlockStmt stmt) = prettyPrec p stmt
-  prettyPrec p (LocalClass cd) = prettyPrec p cd
-  prettyPrec p (LocalVars mods t vds) =
-    hsep (map (prettyPrec p) mods) <+> prettyPrec p t <+> 
+instance Show a => Pretty (BlockStmt a) where
+  prettyPrec p (BlockStmt stmt _) = prettyPrec p stmt
+  prettyPrec p (LocalClass cd _) = prettyPrec p cd
+  prettyPrec p (LocalVars mods t vds _) =
+    hsep (map (prettyPrec p) mods) <+> prettyPrec p t <+>
       hsep (punctuate comma $ map (prettyPrec p) vds) <> semi
 
-instance Pretty Stmt where
-  prettyPrec p (StmtBlock block) = prettyPrec p block
-  prettyPrec p (IfThen c th) =
+instance Show a => Pretty (Stmt a) where
+  prettyPrec p (StmtBlock block _) = prettyPrec p block
+  prettyPrec p (IfThen c th _) =
     text "if" <+> parens (prettyPrec 0 c) $+$ prettyNestedStmt 0 th
 
-  prettyPrec p (IfThenElse c th el) =
+  prettyPrec p (IfThenElse c th el _) =
     text "if" <+> parens (prettyPrec p c) $+$ prettyNestedStmt 0 th $+$ text "else" $+$ prettyNestedStmt 0 el
-      
-  prettyPrec p (While c stmt) =
+
+  prettyPrec p (While c stmt _) =
     text "while" <+> parens (prettyPrec p c) $+$ prettyNestedStmt 0 stmt
-  
-  prettyPrec p (BasicFor mInit mE mUp stmt) =
+
+  prettyPrec p (BasicFor mInit mE mUp stmt _) =
     text "for" <+> (parens $ hsep [maybePP p mInit, semi
                            , maybePP p mE, semi
                            , maybe empty (hsep . punctuate comma . map (prettyPrec p)) mUp
                           ]) $+$ prettyNestedStmt p stmt
 
-  prettyPrec p (EnhancedFor mods t ident e stmt) =
+  prettyPrec p (EnhancedFor mods t ident e stmt _) =
     hsep [text "for"
           , parens $ hsep [
                   hsep (map (prettyPrec p) mods)
@@ -225,244 +225,244 @@ instance Pretty Stmt where
           , prettyPrec p stmt
          ]
 
-  prettyPrec p Empty = semi
-  
-  prettyPrec p (ExpStmt e) = prettyPrec p e <> semi
+  prettyPrec p (Empty _) = semi
 
-  prettyPrec p (Assert ass mE) =
+  prettyPrec p (ExpStmt e _) = prettyPrec p e <> semi
+
+  prettyPrec p (Assert ass mE _) =
     text "assert" <+> prettyPrec p ass
       <+> maybe empty ((colon <>) . prettyPrec p) mE <> semi
 
-  prettyPrec p (Switch e sBlocks) =
-    text "switch" <+> parens (prettyPrec p e) 
+  prettyPrec p (Switch e sBlocks _) =
+    text "switch" <+> parens (prettyPrec p e)
       $$ braceBlock (map (prettyPrec p) sBlocks)
 
-  prettyPrec p (Do stmt e) =
+  prettyPrec p (Do stmt e _) =
     text "do" $+$ prettyPrec p stmt <+> text "while" <+> parens (prettyPrec p e) <> semi
-  
-  prettyPrec p (Break mIdent) =
+
+  prettyPrec p (Break mIdent _) =
     text "break" <+> maybePP p mIdent <> semi
-  
-  prettyPrec p (Continue mIdent) =
+
+  prettyPrec p (Continue mIdent _) =
     text "continue" <+> maybePP p mIdent <> semi
-  
-  prettyPrec p (Return mE) =
+
+  prettyPrec p (Return mE _) =
     text "return" <+> maybePP p mE <> semi
-  
-  prettyPrec p (Synchronized e block) =
+
+  prettyPrec p (Synchronized e block _) =
     text "synchronized" <+> parens (prettyPrec p e) $$ prettyPrec p block
-  
-  prettyPrec p (Throw e) =
+
+  prettyPrec p (Throw e _) =
     text "throw" <+> prettyPrec p e <> semi
-  
-  prettyPrec p (Try block catches mFinally) =
+
+  prettyPrec p (Try block catches mFinally _) =
     text "try" $$ prettyPrec p block $$
       vcat (map (prettyPrec p) catches ++ [ppFinally mFinally])
    where ppFinally Nothing = empty
          ppFinally (Just bl) = text "finally" <+> prettyPrec p bl
 
-  prettyPrec p (Labeled ident stmt) =
+  prettyPrec p (Labeled ident stmt _) =
     prettyPrec p ident <> colon <+> prettyPrec p stmt
 
-instance Pretty Catch where
-  prettyPrec p (Catch fParam block) =
+instance Show a => Pretty (Catch a) where
+  prettyPrec p (Catch fParam block _) =
     hsep [text "catch", parens (prettyPrec p fParam)] $$ prettyPrec p block
 
-instance Pretty SwitchBlock where
-  prettyPrec p (SwitchBlock lbl stmts) =
+instance Show a => Pretty (SwitchBlock a) where
+  prettyPrec p (SwitchBlock lbl stmts _) =
     vcat (prettyPrec p lbl : map (nest 2 . prettyPrec p) stmts)
 
-instance Pretty SwitchLabel where
-  prettyPrec p (SwitchCase e) =
+instance Show a => Pretty (SwitchLabel a) where
+  prettyPrec p (SwitchCase e _) =
     text "case" <+> prettyPrec p e <> colon
-  prettyPrec p Default = text "default:"
+  prettyPrec p (Default _) = text "default:"
 
-instance Pretty ForInit where
-  prettyPrec p (ForLocalVars mods t vds) =
+instance Show a => Pretty (ForInit a) where
+  prettyPrec p (ForLocalVars mods t vds _) =
     hsep $ map (prettyPrec p) mods ++
             prettyPrec p t: punctuate comma (map (prettyPrec p) vds)
-  prettyPrec p (ForInitExps es) =
+  prettyPrec p (ForInitExps es _) =
     hsep $ punctuate comma (map (prettyPrec p) es)
 
 
 -----------------------------------------------------------------------
 -- Expressions
 
-instance Pretty Exp where
-  prettyPrec p (Lit l) = prettyPrec p l
-  
-  prettyPrec p (ClassLit mT) =
+instance Show a => Pretty (Exp a) where
+  prettyPrec p (Lit l _) = prettyPrec p l
+
+  prettyPrec p (ClassLit mT _) =
     ppResultType p mT <> text ".class"
 
-  prettyPrec _ This = text "this"
-  
-  prettyPrec p (ThisClass name) =
+  prettyPrec _ (This _) = text "this"
+
+  prettyPrec p (ThisClass name _) =
     prettyPrec p name <> text ".this"
-    
-  prettyPrec p (InstanceCreation tArgs tds args mBody) =
-    hsep [text "new" 
-          , ppTypeParams p tArgs 
+
+  prettyPrec p (InstanceCreation tArgs tds args mBody _) =
+    hsep [text "new"
+          , ppTypeParams p tArgs
           , prettyPrec p tds <> ppArgs p args
          ] $$ maybePP p mBody
-  
-  prettyPrec p (QualInstanceCreation e tArgs ident args mBody) =
+
+  prettyPrec p (QualInstanceCreation e tArgs ident args mBody _) =
     hsep [prettyPrec p e <> char '.' <> text "new"
           , ppTypeParams p tArgs
           , prettyPrec p ident <> ppArgs p args
          ] $$ maybePP p mBody
 
-  prettyPrec p (ArrayCreate t es k) =
-    text "new" <+> 
-      hcat (prettyPrec p t : map (brackets . prettyPrec p) es 
+  prettyPrec p (ArrayCreate t es k _) =
+    text "new" <+>
+      hcat (prettyPrec p t : map (brackets . prettyPrec p) es
                 ++ replicate k (text "[]"))
-  
-  prettyPrec p (ArrayCreateInit t k init) =
-    text "new" 
-      <+> hcat (prettyPrec p t : replicate k (text "[]")) 
+
+  prettyPrec p (ArrayCreateInit t k init _) =
+    text "new"
+      <+> hcat (prettyPrec p t : replicate k (text "[]"))
       <+> prettyPrec p init
 
-  prettyPrec p (FieldAccess fa) = parenPrec p 1 $ prettyPrec 1 fa
-  
-  prettyPrec p (MethodInv mi) = parenPrec p 1 $ prettyPrec 1 mi
-  
-  prettyPrec p (ArrayAccess ain) = parenPrec p 1 $ prettyPrec 1 ain
+  prettyPrec p (FieldAccess fa _) = parenPrec p 1 $ prettyPrec 1 fa
 
-  prettyPrec p (ExpName name) = prettyPrec p name
-  
-  prettyPrec p (PostIncrement e) = parenPrec p 1 $ prettyPrec 2 e <> text "++"
+  prettyPrec p (MethodInv mi _) = parenPrec p 1 $ prettyPrec 1 mi
 
-  prettyPrec p (PostDecrement e) = parenPrec p 1 $ prettyPrec 2 e <> text "--"
+  prettyPrec p (ArrayAccess ain _) = parenPrec p 1 $ prettyPrec 1 ain
 
-  prettyPrec p (PreIncrement e)  = parenPrec p 1 $ text "++" <> prettyPrec 2 e
-  
-  prettyPrec p (PreDecrement e)  = parenPrec p 1 $ text "--" <> prettyPrec 2 e
+  prettyPrec p (ExpName name _) = prettyPrec p name
 
-  prettyPrec p (PrePlus e) = parenPrec p 2 $ char '+' <> prettyPrec 2 e
-  
-  prettyPrec p (PreMinus e) = parenPrec p 2 $ char '-' <> prettyPrec 2 e
-  
-  prettyPrec p (PreBitCompl e) = parenPrec p 2 $ char '~' <> prettyPrec 2 e 
+  prettyPrec p (PostIncrement e _) = parenPrec p 1 $ prettyPrec 2 e <> text "++"
 
-  prettyPrec p (PreNot e) = parenPrec p 2 $ char '!' <> prettyPrec 2 e
+  prettyPrec p (PostDecrement e _) = parenPrec p 1 $ prettyPrec 2 e <> text "--"
 
-  prettyPrec p (Cast t e) = parenPrec p 2 $ parens (prettyPrec p t) <+> prettyPrec 2 e
-  
-  prettyPrec p (BinOp e1 op e2) =
+  prettyPrec p (PreIncrement e _)  = parenPrec p 1 $ text "++" <> prettyPrec 2 e
+
+  prettyPrec p (PreDecrement e _)  = parenPrec p 1 $ text "--" <> prettyPrec 2 e
+
+  prettyPrec p (PrePlus e _) = parenPrec p 2 $ char '+' <> prettyPrec 2 e
+
+  prettyPrec p (PreMinus e _) = parenPrec p 2 $ char '-' <> prettyPrec 2 e
+
+  prettyPrec p (PreBitCompl e _) = parenPrec p 2 $ char '~' <> prettyPrec 2 e
+
+  prettyPrec p (PreNot e _) = parenPrec p 2 $ char '!' <> prettyPrec 2 e
+
+  prettyPrec p (Cast t e _) = parenPrec p 2 $ parens (prettyPrec p t) <+> prettyPrec 2 e
+
+  prettyPrec p (BinOp e1 op e2 _) =
     let prec = opPrec op in
     parenPrec p prec (prettyPrec prec e1 <+> prettyPrec p op <+> prettyPrec prec e2)
 
-  prettyPrec p (InstanceOf e rt) =
-    let cp = opPrec LThan in
+  prettyPrec p (InstanceOf e rt _) =
+    let cp = opPrec (LThan ()) in
     parenPrec p cp $ prettyPrec cp e
                    <+> text "instanceof" <+> prettyPrec cp rt
-    
-  prettyPrec p (Cond c th el) =
+
+  prettyPrec p (Cond c th el _) =
     parenPrec p 13 $ prettyPrec 13 c <+> char '?'
                    <+> prettyPrec p th <+> colon <+> prettyPrec 13 el
 
-  prettyPrec p (Assign lhs aop e) =
+  prettyPrec p (Assign lhs aop e _) =
     hsep [prettyPrec p lhs, prettyPrec p aop, prettyPrec p e]
 
-  prettyPrec p (Lambda params body) =
+  prettyPrec p (Lambda params body _) =
     prettyPrec p params <+> text "->" <+> prettyPrec p body
 
-  prettyPrec p (MethodRef i1 i2) =
+  prettyPrec p (MethodRef i1 i2 _) =
     prettyPrec p i1 <+> text "::" <+> prettyPrec p i2
 
-instance Pretty LambdaParams where
-  prettyPrec p (LambdaSingleParam ident) = prettyPrec p ident
-  prettyPrec p (LambdaFormalParams params) = ppArgs p params
-  prettyPrec p (LambdaInferredParams idents) = ppArgs p idents
+instance Show a => Pretty (LambdaParams a) where
+  prettyPrec p (LambdaSingleParam ident _) = prettyPrec p ident
+  prettyPrec p (LambdaFormalParams params _) = ppArgs p params
+  prettyPrec p (LambdaInferredParams idents _) = ppArgs p idents
 
-instance Pretty LambdaExpression where
-  prettyPrec p (LambdaExpression exp) = prettyPrec p exp
-  prettyPrec p (LambdaBlock block) = prettyPrec p block
+instance Show a => Pretty (LambdaExpression a) where
+  prettyPrec p (LambdaExpression exp _) = prettyPrec p exp
+  prettyPrec p (LambdaBlock block _) = prettyPrec p block
 
-instance Pretty Literal where
-  prettyPrec p (Int i) = text (show i)
-  prettyPrec p (Word i) = text (show i) <> char 'L'
-  prettyPrec p (Float f) = text (show f) <> char 'F'
-  prettyPrec p (Double d) = text (show d)
-  prettyPrec p (Boolean b) = text . map toLower $ show b
-  prettyPrec p (Char c) = quotes $ text (escapeChar c)
-  prettyPrec p (String s) = doubleQuotes $ text (concatMap escapeString s)
-  prettyPrec p (Null) = text "null"
+instance Pretty (Literal a) where
+  prettyPrec p (Int i _) = text (show i)
+  prettyPrec p (Word i _) = text (show i) <> char 'L'
+  prettyPrec p (Float f _) = text (show f) <> char 'F'
+  prettyPrec p (Double d _) = text (show d)
+  prettyPrec p (Boolean b _) = text . map toLower $ show b
+  prettyPrec p (Char c _) = quotes $ text (escapeChar c)
+  prettyPrec p (String s _) = doubleQuotes $ text (concatMap escapeString s)
+  prettyPrec p (Null _) = text "null"
 
-instance Pretty Op where
+instance Pretty (Op a) where
   prettyPrec p op = text $ case op of
-    Mult    -> "*"
-    Div     -> "/"
-    Rem     -> "%"
-    Add     -> "+"
-    Sub     -> "-"
-    LShift  -> "<<"
-    RShift  -> ">>"
-    RRShift -> ">>>"
-    LThan   -> "<"
-    GThan   -> ">"
-    LThanE  -> "<="
-    GThanE  -> ">="
-    Equal   -> "=="
-    NotEq   -> "!="
-    And     -> "&"
-    Xor     -> "^"
-    Or      -> "|"
-    CAnd    -> "&&"
-    COr     -> "||"
-    
-instance Pretty AssignOp where
+    Mult _    -> "*"
+    Div _     -> "/"
+    Rem _     -> "%"
+    Add _     -> "+"
+    Sub _     -> "-"
+    LShift _  -> "<<"
+    RShift _  -> ">>"
+    RRShift _ -> ">>>"
+    LThan _   -> "<"
+    GThan _   -> ">"
+    LThanE _  -> "<="
+    GThanE _  -> ">="
+    Equal _   -> "=="
+    NotEq _   -> "!="
+    And _     -> "&"
+    Xor _     -> "^"
+    Or _      -> "|"
+    CAnd _    -> "&&"
+    COr _     -> "||"
+
+instance Pretty (AssignOp a) where
   prettyPrec p aop = text $ case aop of
-    EqualA  -> "="
-    MultA   -> "*="
-    DivA    -> "/="
-    RemA    -> "%="
-    AddA    -> "+="
-    SubA    -> "-="
-    LShiftA -> "<<="
-    RShiftA -> ">>="
-    RRShiftA -> ">>>="
-    AndA    -> "&="
-    XorA    -> "^="
-    OrA     -> "|="
+    EqualA _  -> "="
+    MultA _   -> "*="
+    DivA _    -> "/="
+    RemA _    -> "%="
+    AddA _    -> "+="
+    SubA _    -> "-="
+    LShiftA _ -> "<<="
+    RShiftA _ -> ">>="
+    RRShiftA _ -> ">>>="
+    AndA _    -> "&="
+    XorA _    -> "^="
+    OrA _     -> "|="
 
-instance Pretty Lhs where
-  prettyPrec p (NameLhs name) = prettyPrec p name
-  prettyPrec p (FieldLhs fa) = prettyPrec p fa
-  prettyPrec p (ArrayLhs ain) = prettyPrec p ain
+instance Show a => Pretty (Lhs a) where
+  prettyPrec p (NameLhs name _) = prettyPrec p name
+  prettyPrec p (FieldLhs fa _) = prettyPrec p fa
+  prettyPrec p (ArrayLhs ain _) = prettyPrec p ain
 
-instance Pretty ArrayIndex where
-  prettyPrec p (ArrayIndex ref e) = prettyPrec p ref <> (hcat $ map (brackets . (prettyPrec p)) e)
+instance Show a => Pretty (ArrayIndex a) where
+  prettyPrec p (ArrayIndex ref e _) = prettyPrec p ref <> (hcat $ map (brackets . (prettyPrec p)) e)
 
-instance Pretty FieldAccess where
-  prettyPrec p (PrimaryFieldAccess e ident) =
+instance Show a => Pretty (FieldAccess a) where
+  prettyPrec p (PrimaryFieldAccess e ident _) =
     prettyPrec p e <> char '.' <> prettyPrec p ident
-  prettyPrec p (SuperFieldAccess ident) =
+  prettyPrec p (SuperFieldAccess ident _) =
     text "super." <> prettyPrec p ident
-  prettyPrec p (ClassFieldAccess name ident) =
+  prettyPrec p (ClassFieldAccess name ident _) =
     prettyPrec p name <> text "." <> prettyPrec p ident
 
-instance Pretty MethodInvocation where
-  prettyPrec p (MethodCall name args) =
+instance Show a => Pretty (MethodInvocation a) where
+  prettyPrec p (MethodCall name args _) =
     prettyPrec p name <> ppArgs p args
 
-  prettyPrec p (PrimaryMethodCall e tArgs ident args) =
-    hcat [prettyPrec p e, char '.', ppTypeParams p tArgs, 
+  prettyPrec p (PrimaryMethodCall e tArgs ident args _) =
+    hcat [prettyPrec p e, char '.', ppTypeParams p tArgs,
            prettyPrec p ident, ppArgs p args]
 
-  prettyPrec p (SuperMethodCall tArgs ident args) =
+  prettyPrec p (SuperMethodCall tArgs ident args _) =
     hcat [text "super.", ppTypeParams p tArgs,
            prettyPrec p ident, ppArgs p args]
 
-  prettyPrec p (ClassMethodCall name tArgs ident args) =
+  prettyPrec p (ClassMethodCall name tArgs ident args _) =
     hcat [prettyPrec p name, text ".super.", ppTypeParams p tArgs,
            prettyPrec p ident, ppArgs p args]
-  
-  prettyPrec p (TypeMethodCall name tArgs ident args) =
+
+  prettyPrec p (TypeMethodCall name tArgs ident args _) =
     hcat [prettyPrec p name, char '.', ppTypeParams p tArgs,
            prettyPrec p ident, ppArgs p args]
 
-instance Pretty ArrayInit where
-  prettyPrec p (ArrayInit vInits) =
+instance Show a => Pretty (ArrayInit a) where
+  prettyPrec p (ArrayInit vInits _) =
     braceBlock $ map (\v -> prettyPrec p v <> comma) vInits
     --braces $ hsep (punctuate comma (map (prettyPrec p) vInits))
 
@@ -473,96 +473,96 @@ ppArgs p = parens . hsep . punctuate comma . map (prettyPrec p)
 -----------------------------------------------------------------------
 -- Types
 
-instance Pretty Type where
-  prettyPrec p (PrimType pt) = prettyPrec p pt
-  prettyPrec p (RefType  rt) = prettyPrec p rt
+instance Pretty (Type a) where
+  prettyPrec p (PrimType pt _) = prettyPrec p pt
+  prettyPrec p (RefType  rt _) = prettyPrec p rt
 
-instance Pretty RefType where
-  prettyPrec p (ClassRefType ct) = prettyPrec p ct
-  prettyPrec p (ArrayType t) = prettyPrec p t <> text "[]"
+instance Pretty (RefType a) where
+  prettyPrec p (ClassRefType ct _) = prettyPrec p ct
+  prettyPrec p (ArrayType t _) = prettyPrec p t <> text "[]"
 
-instance Pretty ClassType where
-  prettyPrec p (ClassType itas) =
+instance Pretty (ClassType a) where
+  prettyPrec p (ClassType itas _) =
     hcat . punctuate (char '.') $
       map (\(i,tas) -> prettyPrec p i <> ppTypeParams p tas) itas
 
-instance Pretty TypeArgument where
-  prettyPrec p (ActualType rt) = prettyPrec p rt
-  prettyPrec p (Wildcard mBound) = char '?' <+> maybePP p mBound
+instance Pretty (TypeArgument a) where
+  prettyPrec p (ActualType rt _) = prettyPrec p rt
+  prettyPrec p (Wildcard mBound _) = char '?' <+> maybePP p mBound
 
-instance Pretty TypeDeclSpecifier where
-  prettyPrec p (TypeDeclSpecifier ct) = prettyPrec p ct
-  prettyPrec p (TypeDeclSpecifierWithDiamond ct i d) =  prettyPrec p ct <> char '.' <> prettyPrec p i <> prettyPrec p d
-  prettyPrec p (TypeDeclSpecifierUnqualifiedWithDiamond i d) = prettyPrec p i <> prettyPrec p d
+instance Pretty (TypeDeclSpecifier a) where
+  prettyPrec p (TypeDeclSpecifier ct _) = prettyPrec p ct
+  prettyPrec p (TypeDeclSpecifierWithDiamond ct i d _) =  prettyPrec p ct <> char '.' <> prettyPrec p i <> prettyPrec p d
+  prettyPrec p (TypeDeclSpecifierUnqualifiedWithDiamond i d _) = prettyPrec p i <> prettyPrec p d
 
-instance Pretty Diamond where
-  prettyPrec p Diamond = text "<>"
+instance Pretty (Diamond a) where
+  prettyPrec p (Diamond _) = text "<>"
 
-instance Pretty WildcardBound where
-  prettyPrec p (ExtendsBound rt) = text "extends" <+> prettyPrec p rt
-  prettyPrec p (SuperBound   rt) = text "super"   <+> prettyPrec p rt
+instance Pretty (WildcardBound a) where
+  prettyPrec p (ExtendsBound rt _) = text "extends" <+> prettyPrec p rt
+  prettyPrec p (SuperBound   rt _) = text "super"   <+> prettyPrec p rt
 
-instance Pretty PrimType where
-  prettyPrec p BooleanT = text "boolean"
-  prettyPrec p ByteT    = text "byte"
-  prettyPrec p ShortT   = text "short"
-  prettyPrec p IntT     = text "int"
-  prettyPrec p LongT    = text "long"
-  prettyPrec p CharT    = text "char"
-  prettyPrec p FloatT   = text "float"
-  prettyPrec p DoubleT  = text "double"
+instance Pretty (PrimType a) where
+  prettyPrec p (BooleanT _) = text "boolean"
+  prettyPrec p (ByteT _)    = text "byte"
+  prettyPrec p (ShortT _)   = text "short"
+  prettyPrec p (IntT _)     = text "int"
+  prettyPrec p (LongT _)    = text "long"
+  prettyPrec p (CharT _)    = text "char"
+  prettyPrec p (FloatT _)   = text "float"
+  prettyPrec p (DoubleT _)  = text "double"
 
-instance Pretty TypeParam where
-  prettyPrec p (TypeParam ident rts) =
-    prettyPrec p ident 
-      <+> opt (not $ null rts) 
-           (hsep $ text "extends": 
+instance Pretty (TypeParam a) where
+  prettyPrec p (TypeParam ident rts _) =
+    prettyPrec p ident
+      <+> opt (not $ null rts)
+           (hsep $ text "extends":
                     punctuate (text " &") (map (prettyPrec p) rts))
 
 ppTypeParams :: Pretty a => Int -> [a] -> Doc
 ppTypeParams _ [] = empty
-ppTypeParams p tps = char '<' 
+ppTypeParams p tps = char '<'
     <> hsep (punctuate comma (map (prettyPrec p) tps))
     <> char '>'
 
-ppImplements :: Int -> [RefType] -> Doc
+ppImplements :: Int -> [RefType a] -> Doc
 ppImplements _ [] = empty
-ppImplements p rts = text "implements" 
+ppImplements p rts = text "implements"
     <+> hsep (punctuate comma (map (prettyPrec p) rts))
 
-ppExtends :: Int -> [RefType] -> Doc
+ppExtends :: Int -> [RefType a] -> Doc
 ppExtends _ [] = empty
-ppExtends p rts = text "extends" 
+ppExtends p rts = text "extends"
     <+> hsep (punctuate comma (map (prettyPrec p) rts))
 
-ppThrows :: Int -> [ExceptionType] -> Doc
+ppThrows :: Int -> [ExceptionType a] -> Doc
 ppThrows _ [] = empty
-ppThrows p ets = text "throws" 
+ppThrows p ets = text "throws"
     <+> hsep (punctuate comma (map (prettyPrec p) ets))
 
-ppDefault :: Int -> Maybe Exp -> Doc
+ppDefault :: Show a => Int -> Maybe (Exp a) -> Doc
 ppDefault _ Nothing = empty
 ppDefault p (Just exp) = text "default" <+> prettyPrec p exp
 
-ppResultType :: Int -> Maybe Type -> Doc
+ppResultType :: Int -> Maybe (Type a) -> Doc
 ppResultType _ Nothing = text "void"
 ppResultType p (Just a) = prettyPrec p a
 
 -----------------------------------------------------------------------
 -- Names and identifiers
 
-instance Pretty Name where
-  prettyPrec p (Name is) =
+instance Pretty (Name a) where
+  prettyPrec p (Name is _) =
     hcat (punctuate (char '.') $ map (prettyPrec p) is)
 
-instance Pretty Ident where
-  prettyPrec p (Ident s) = text s
+instance Pretty (Ident a) where
+  prettyPrec p (Ident s _) = text s
 
 
 -----------------------------------------------------------------------
 -- Help functionality
-prettyNestedStmt :: Int -> Stmt -> Doc
-prettyNestedStmt prio p@(StmtBlock b) = prettyPrec prio p
+prettyNestedStmt :: Show a => Int -> Stmt a -> Doc
+prettyNestedStmt prio p@(StmtBlock b _) = prettyPrec prio p
 prettyNestedStmt prio p = nest 2 (prettyPrec prio p)
 
 maybePP :: Pretty a => Int -> Maybe a -> Doc
@@ -576,25 +576,25 @@ braceBlock xs = char '{'
     $+$ nest 2 (vcat xs)
     $+$ char '}'
 
-opPrec Mult    = 3
-opPrec Div     = 3
-opPrec Rem     = 3
-opPrec Add     = 4
-opPrec Sub     = 4
-opPrec LShift  = 5
-opPrec RShift  = 5
-opPrec RRShift = 5
-opPrec LThan   = 6
-opPrec GThan   = 6
-opPrec LThanE  = 6
-opPrec GThanE  = 6
-opPrec Equal   = 7
-opPrec NotEq   = 7
-opPrec And     = 8
-opPrec Xor     = 9
-opPrec Or      = 10
-opPrec CAnd    = 11
-opPrec COr     = 12
+opPrec (Mult _)    = 3
+opPrec (Div _)     = 3
+opPrec (Rem _)     = 3
+opPrec (Add _)     = 4
+opPrec (Sub _)     = 4
+opPrec (LShift _)  = 5
+opPrec (RShift _)  = 5
+opPrec (RRShift _) = 5
+opPrec (LThan _)   = 6
+opPrec (GThan _)   = 6
+opPrec (LThanE _)  = 6
+opPrec (GThanE _)  = 6
+opPrec (Equal _)   = 7
+opPrec (NotEq _)   = 7
+opPrec (And _)     = 8
+opPrec (Xor _)     = 9
+opPrec (Or _)      = 10
+opPrec (CAnd _)    = 11
+opPrec (COr _)     = 12
 
 escapeGeneral :: Char -> String
 escapeGeneral '\b' = "\\b"

--- a/Language/Java/Pretty.hs
+++ b/Language/Java/Pretty.hs
@@ -31,8 +31,8 @@ class Pretty a where
 -----------------------------------------------------------------------
 -- Packages
 
-instance Pretty CompilationUnit where
-  prettyPrec p (CompilationUnit mpd ids tds) =
+instance Pretty (CompilationUnit a) where
+  prettyPrec p (CompilationUnit mpd ids tds a) =
     vcat $ ((maybePP p mpd): map (prettyPrec p) ids) ++ map (prettyPrec p) tds
 
 instance Pretty PackageDecl where

--- a/Language/Java/Pretty.hs
+++ b/Language/Java/Pretty.hs
@@ -329,21 +329,21 @@ instance Show a => Pretty (Exp a) where
 
   prettyPrec p (ExpName name _) = prettyPrec p name
 
-  prettyPrec p (PostIncrement e _) = parenPrec p 1 $ prettyPrec 2 e <> text "++"
+  prettyPrec p (PostIncrement _ e) = parenPrec p 1 $ prettyPrec 2 e <> text "++"
 
-  prettyPrec p (PostDecrement e _) = parenPrec p 1 $ prettyPrec 2 e <> text "--"
+  prettyPrec p (PostDecrement _ e) = parenPrec p 1 $ prettyPrec 2 e <> text "--"
 
-  prettyPrec p (PreIncrement e _)  = parenPrec p 1 $ text "++" <> prettyPrec 2 e
+  prettyPrec p (PreIncrement _ e)  = parenPrec p 1 $ text "++" <> prettyPrec 2 e
 
-  prettyPrec p (PreDecrement e _)  = parenPrec p 1 $ text "--" <> prettyPrec 2 e
+  prettyPrec p (PreDecrement _ e)  = parenPrec p 1 $ text "--" <> prettyPrec 2 e
 
-  prettyPrec p (PrePlus e _) = parenPrec p 2 $ char '+' <> prettyPrec 2 e
+  prettyPrec p (PrePlus _ e) = parenPrec p 2 $ char '+' <> prettyPrec 2 e
 
-  prettyPrec p (PreMinus e _) = parenPrec p 2 $ char '-' <> prettyPrec 2 e
+  prettyPrec p (PreMinus _ e) = parenPrec p 2 $ char '-' <> prettyPrec 2 e
 
-  prettyPrec p (PreBitCompl e _) = parenPrec p 2 $ char '~' <> prettyPrec 2 e
+  prettyPrec p (PreBitCompl _ e) = parenPrec p 2 $ char '~' <> prettyPrec 2 e
 
-  prettyPrec p (PreNot e _) = parenPrec p 2 $ char '!' <> prettyPrec 2 e
+  prettyPrec p (PreNot _ e) = parenPrec p 2 $ char '!' <> prettyPrec 2 e
 
   prettyPrec p (Cast t e _) = parenPrec p 2 $ parens (prettyPrec p t) <+> prettyPrec 2 e
 

--- a/Language/Java/Syntax.hs
+++ b/Language/Java/Syntax.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveDataTypeable, DeriveGeneric, DeriveFunctor #-}
+{-# LANGUAGE DeriveDataTypeable, DeriveGeneric, DeriveFunctor, DeriveFoldable, DeriveTraversable #-}
 module Language.Java.Syntax
     ( CompilationUnit(..)
     , PackageDecl(..)
@@ -59,11 +59,11 @@ import Language.Java.Syntax.Exp
 
 -- | A compilation unit is the top level syntactic goal symbol of a Java program.
 data CompilationUnit a = CompilationUnit (Maybe (PackageDecl a)) [ImportDecl a] [TypeDecl a] a
-  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor, Foldable, Traversable)
 
 -- | A package declaration appears within a compilation unit to indicate the package to which the compilation unit belongs.
 data PackageDecl a = PackageDecl (Name a) a
-  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor, Foldable, Traversable)
 
 -- | An import declaration allows a static member or a named type to be referred to by a single unqualified identifier.
 --   The first argument signals whether the declaration only imports static members.
@@ -71,7 +71,7 @@ data PackageDecl a = PackageDecl (Name a) a
 --   a single name into scope.
 data ImportDecl a
     = ImportDecl Bool {- static? -} (Name a) Bool {- .*? -} a
-  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor, Foldable, Traversable)
 
 
 -----------------------------------------------------------------------
@@ -81,28 +81,28 @@ data ImportDecl a
 data TypeDecl a
     = ClassTypeDecl (ClassDecl a) a
     | InterfaceTypeDecl (InterfaceDecl a) a
-  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor, Foldable, Traversable)
 
 -- | A class declaration specifies a new named reference type.
 data ClassDecl a
     = ClassDecl [Modifier a] (Ident a) [TypeParam a] (Maybe (RefType a)) [RefType a] (ClassBody a) a
     | EnumDecl  [Modifier a] (Ident a)                             [RefType a] (EnumBody a) a
-  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor, Foldable, Traversable)
 
 -- | A class body may contain declarations of members of the class, that is,
 --   fields, classes, interfaces and methods.
 --   A class body may also contain instance initializers, static
 --   initializers, and declarations of constructors for the class.
 data ClassBody a = ClassBody [Decl a] a
-  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor, Foldable, Traversable)
 
 -- | The body of an enum type may contain enum constants.
 data EnumBody a = EnumBody [EnumConstant a] [Decl a] a
-  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor, Foldable, Traversable)
 
 -- | An enum constant defines an instance of the enum type.
 data EnumConstant a = EnumConstant (Ident a) [Argument a] (Maybe (ClassBody a)) a
-  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor, Foldable, Traversable)
 
 -- | An interface declaration introduces a new reference type whose members
 --   are classes, interfaces, constants and abstract methods. This type has
@@ -110,7 +110,7 @@ data EnumConstant a = EnumConstant (Ident a) [Argument a] (Maybe (ClassBody a)) 
 --   providing implementations for its abstract methods.
 data InterfaceDecl a
     = InterfaceDecl InterfaceKind [Modifier a] (Ident a) [TypeParam a] [RefType a] (InterfaceBody a) a
-  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor, Foldable, Traversable)
 
 -- | Interface can declare either a normal interface or an annotation
 data InterfaceKind = InterfaceNormal | InterfaceAnnotation
@@ -119,14 +119,14 @@ data InterfaceKind = InterfaceNormal | InterfaceAnnotation
 -- | The body of an interface may declare members of the interface.
 data InterfaceBody a
     = InterfaceBody [MemberDecl a] a
-  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor, Foldable, Traversable)
 
 -- | A declaration is either a member declaration, or a declaration of an
 --   initializer, which may be static.
 data Decl a
     = MemberDecl (MemberDecl a) a
     | InitDecl Bool (Block a) a
-  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor, Foldable, Traversable)
 
 
 -- | A class or interface member can be an inner class or interface, a field or
@@ -143,42 +143,42 @@ data MemberDecl a
     | MemberClassDecl (ClassDecl a) a
     -- | A member interface is an interface whose declaration is directly enclosed in another class or interface declaration.
     | MemberInterfaceDecl (InterfaceDecl a) a
-  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor, Foldable, Traversable)
 
 
 -- | A declaration of a variable, which may be explicitly initialized.
 data VarDecl a
     = VarDecl (VarDeclId a) (Maybe (VarInit a)) a
-  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor, Foldable, Traversable)
 
 -- | The name of a variable in a declaration, which may be an array.
 data VarDeclId a
     = VarId (Ident a) a
     | VarDeclArray (VarDeclId a) a
     -- ^ Multi-dimensional arrays are represented by nested applications of 'VarDeclArray'.
-  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor, Foldable, Traversable)
 
 -- | Explicit initializer for a variable declaration.
 data VarInit a
     = InitExp (Exp a) a
     | InitArray (ArrayInit a) a
-  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor, Foldable, Traversable)
 
 -- | A formal parameter in method declaration. The last parameter
 --   for a given declaration may be marked as variable arity,
 --   indicated by the boolean argument.
 data FormalParam a = FormalParam [Modifier a] (Type a) Bool (VarDeclId a) a
-  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor, Foldable, Traversable)
 
 -- | A method body is either a block of code that implements the method or simply a
 --   semicolon, indicating the lack of an implementation (modelled by 'Nothing').
 data MethodBody a = MethodBody (Maybe (Block a)) a
-  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor, Foldable, Traversable)
 
 -- | The first statement of a constructor body may be an explicit invocation of
 --   another constructor of the same class or of the direct superclass.
 data ConstructorBody a = ConstructorBody (Maybe (ExplConstrInv a)) [BlockStmt a] a
-  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor, Foldable, Traversable)
 
 -- | An explicit constructor invocation invokes another constructor of the
 --   same class, or a constructor of the direct superclass, which may
@@ -188,7 +188,7 @@ data ExplConstrInv a
     = ThisInvoke             [RefType a] [Argument a] a
     | SuperInvoke            [RefType a] [Argument a] a
     | PrimarySuperInvoke (Exp a) [RefType a] [Argument a] a
-  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor, Foldable, Traversable)
 
 
 -- | A modifier specifying properties of a given declaration. In general only
@@ -207,7 +207,7 @@ data Modifier a
     | Native a
     | Annotation (Annotation a) a
     | Synchronized_ a
-  deriving (Eq,Read,Typeable,Generic,Data, Functor)
+  deriving (Eq,Read,Typeable,Generic,Data, Functor, Foldable, Traversable)
 
 instance Show a => Show (Modifier a) where
    show (Public _) = "public"
@@ -235,7 +235,7 @@ data Annotation a = NormalAnnotation        { annName :: Name a-- Not type becau
                   | MarkerAnnotation        { annName :: Name a
                                             , srcInfo :: a}
 
-  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor, Foldable, Traversable)
 
 
 desugarAnnotation :: Annotation a -> (Name a, [(Ident a, ElementValue a)], a)
@@ -250,7 +250,7 @@ desugarAnnotation' = uncurry3 NormalAnnotation . desugarAnnotation
 -- | Annotations may contain  annotations or (loosely) expressions
 data ElementValue a = EVVal (VarInit a) a
                   | EVAnn (Annotation a) a
-  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor, Foldable, Traversable)
 
 evInfo :: ElementValue a -> a
 evInfo (EVVal _ a) = a
@@ -261,7 +261,7 @@ evInfo (EVAnn _ a) = a
 -- | A block is a sequence of statements, local class declarations
 --   and local variable declaration statements within braces.
 data Block a = Block [BlockStmt a] a
-  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor, Foldable, Traversable)
 
 
 
@@ -271,7 +271,7 @@ data BlockStmt a
     = BlockStmt (Stmt a) a
     | LocalClass (ClassDecl a) a
     | LocalVars [Modifier a] (Type a) [VarDecl a] a
-  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor, Foldable, Traversable)
 
 
 -- | A Java statement.
@@ -321,30 +321,30 @@ data Stmt a
     | Try (Block a) [Catch a] (Maybe {- finally -} (Block a)) a
     -- | Statements may have label prefixes.
     | Labeled (Ident a) (Stmt a) a
-  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor, Foldable, Traversable)
 
 -- | If a value is thrown and the try statement has one or more catch clauses that can catch it, then control will be
 --   transferred to the first such catch clause.
 data Catch a = Catch (FormalParam a) (Block a) a
-  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor, Foldable, Traversable)
 
 -- | A block of code labelled with a @case@ or @default@ within a @switch@ statement.
 data SwitchBlock a
     = SwitchBlock (SwitchLabel a) [BlockStmt a] a
-  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor, Foldable, Traversable)
 
 -- | A label within a @switch@ statement.
 data SwitchLabel a
     -- | The expression contained in the @case@ must be a 'Lit' or an @enum@ constant.
     = SwitchCase (Exp a) a
     | Default a
-  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor, Foldable, Traversable)
 
 -- | Initialization code for a basic @for@ statement.
 data ForInit a
     = ForLocalVars [Modifier a] (Type a) [VarDecl a] a
     | ForInitExps [Exp a] a
-  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor, Foldable, Traversable)
 
 -- | An exception type has to be a class type or a type variable.
 type ExceptionType a = RefType a -- restricted to ClassType or TypeVariable
@@ -421,7 +421,7 @@ data Exp a
     | Lambda (LambdaParams a) (LambdaExpression a) a
     -- | Method reference
     | MethodRef (Name a) (Ident a) a
-  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor, Foldable, Traversable)
 
 -- | The left-hand side of an assignment expression. This operand may be a named variable, such as a local
 --   variable or a field of the current object or class, or it may be a computed variable, as can result from
@@ -430,11 +430,11 @@ data Lhs a
     = NameLhs (Name a) a          -- ^ Assign to a variable
     | FieldLhs (FieldAccess a) a  -- ^ Assign through a field access
     | ArrayLhs (ArrayIndex a) a   -- ^ Assign to an array
-  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor, Foldable, Traversable)
 
 -- | Array access
 data ArrayIndex a = ArrayIndex (Exp a) [Exp a] a    -- ^ Index into an array
-  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor, Foldable, Traversable)
 
 -- | A field access expression may access a field of an object or array, a reference to which is the value
 --   of either an expression or the special keyword super.
@@ -442,7 +442,7 @@ data FieldAccess a
     = PrimaryFieldAccess (Exp a) (Ident a) a      -- ^ Accessing a field of an object or array computed from an expression.
     | SuperFieldAccess (Ident a) a            -- ^ Accessing a field of the superclass.
     | ClassFieldAccess (Name a) (Ident a) a       -- ^ Accessing a (static) field of a named class.
-  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor, Foldable, Traversable)
 
 
 -- ¦ A lambda parameter can be a single parameter, or mulitple formal or mulitple inferred parameters
@@ -450,13 +450,13 @@ data LambdaParams a
   = LambdaSingleParam (Ident a) a
   | LambdaFormalParams [FormalParam a] a
   | LambdaInferredParams [Ident a] a
-    deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
+    deriving (Eq,Show,Read,Typeable,Generic,Data, Functor, Foldable, Traversable)
 
 -- | Lambda expression, starting from java 8
 data LambdaExpression a
     = LambdaExpression (Exp a) a
     | LambdaBlock (Block a) a
-  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor, Foldable, Traversable)
 
 
 -- | A method invocation expression is used to invoke a class or instance method.
@@ -471,10 +471,10 @@ data MethodInvocation a
     | ClassMethodCall (Name a) [RefType a] (Ident a) [Argument a] a
     -- | Invoking a method of a named type, giving arguments for any generic type parameters.
     | TypeMethodCall  (Name a) [RefType a] (Ident a) [Argument a] a
-  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor, Foldable, Traversable)
 
 -- | An array initializer may be specified in a declaration, or as part of an array creation expression, creating an
 --   array and providing some initial values
 data ArrayInit a
     = ArrayInit [VarInit a] a
-  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor, Foldable, Traversable)

--- a/Language/Java/Syntax.hs
+++ b/Language/Java/Syntax.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveDataTypeable, DeriveGeneric #-}
+{-# LANGUAGE DeriveDataTypeable, DeriveGeneric, DeriveFunctor #-}
 module Language.Java.Syntax
     ( CompilationUnit(..)
     , PackageDecl(..)
@@ -59,12 +59,11 @@ import Language.Java.Syntax.Exp
 
 -- | A compilation unit is the top level syntactic goal symbol of a Java program.
 data CompilationUnit a = CompilationUnit (Maybe (PackageDecl a)) [ImportDecl a] [TypeDecl a] a
-  deriving (Eq,Show,Read,Typeable,Generic,Data)
-
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
 
 -- | A package declaration appears within a compilation unit to indicate the package to which the compilation unit belongs.
 data PackageDecl a = PackageDecl (Name a) a
-  deriving (Eq,Show,Read,Typeable,Generic,Data)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
 
 -- | An import declaration allows a static member or a named type to be referred to by a single unqualified identifier.
 --   The first argument signals whether the declaration only imports static members.
@@ -72,7 +71,7 @@ data PackageDecl a = PackageDecl (Name a) a
 --   a single name into scope.
 data ImportDecl a
     = ImportDecl Bool {- static? -} (Name a) Bool {- .*? -} a
-  deriving (Eq,Show,Read,Typeable,Generic,Data)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
 
 
 -----------------------------------------------------------------------
@@ -82,28 +81,28 @@ data ImportDecl a
 data TypeDecl a
     = ClassTypeDecl (ClassDecl a) a
     | InterfaceTypeDecl (InterfaceDecl a) a
-  deriving (Eq,Show,Read,Typeable,Generic,Data)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
 
 -- | A class declaration specifies a new named reference type.
 data ClassDecl a
     = ClassDecl [Modifier a] (Ident a) [TypeParam a] (Maybe (RefType a)) [RefType a] (ClassBody a) a
     | EnumDecl  [Modifier a] (Ident a)                             [RefType a] (EnumBody a) a
-  deriving (Eq,Show,Read,Typeable,Generic,Data)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
 
 -- | A class body may contain declarations of members of the class, that is,
 --   fields, classes, interfaces and methods.
 --   A class body may also contain instance initializers, static
 --   initializers, and declarations of constructors for the class.
 data ClassBody a = ClassBody [Decl a] a
-  deriving (Eq,Show,Read,Typeable,Generic,Data)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
 
 -- | The body of an enum type may contain enum constants.
 data EnumBody a = EnumBody [EnumConstant a] [Decl a] a
-  deriving (Eq,Show,Read,Typeable,Generic,Data)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
 
 -- | An enum constant defines an instance of the enum type.
 data EnumConstant a = EnumConstant (Ident a) [Argument a] (Maybe (ClassBody a)) a
-  deriving (Eq,Show,Read,Typeable,Generic,Data)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
 
 -- | An interface declaration introduces a new reference type whose members
 --   are classes, interfaces, constants and abstract methods. This type has
@@ -111,7 +110,7 @@ data EnumConstant a = EnumConstant (Ident a) [Argument a] (Maybe (ClassBody a)) 
 --   providing implementations for its abstract methods.
 data InterfaceDecl a
     = InterfaceDecl InterfaceKind [Modifier a] (Ident a) [TypeParam a] [RefType a] (InterfaceBody a) a
-  deriving (Eq,Show,Read,Typeable,Generic,Data)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
 
 -- | Interface can declare either a normal interface or an annotation
 data InterfaceKind = InterfaceNormal | InterfaceAnnotation
@@ -120,14 +119,14 @@ data InterfaceKind = InterfaceNormal | InterfaceAnnotation
 -- | The body of an interface may declare members of the interface.
 data InterfaceBody a
     = InterfaceBody [MemberDecl a] a
-  deriving (Eq,Show,Read,Typeable,Generic,Data)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
 
 -- | A declaration is either a member declaration, or a declaration of an
 --   initializer, which may be static.
 data Decl a
     = MemberDecl (MemberDecl a) a
     | InitDecl Bool (Block a) a
-  deriving (Eq,Show,Read,Typeable,Generic,Data)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
 
 
 -- | A class or interface member can be an inner class or interface, a field or
@@ -144,42 +143,42 @@ data MemberDecl a
     | MemberClassDecl (ClassDecl a) a
     -- | A member interface is an interface whose declaration is directly enclosed in another class or interface declaration.
     | MemberInterfaceDecl (InterfaceDecl a) a
-  deriving (Eq,Show,Read,Typeable,Generic,Data)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
 
 
 -- | A declaration of a variable, which may be explicitly initialized.
 data VarDecl a
     = VarDecl (VarDeclId a) (Maybe (VarInit a)) a
-  deriving (Eq,Show,Read,Typeable,Generic,Data)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
 
 -- | The name of a variable in a declaration, which may be an array.
 data VarDeclId a
     = VarId (Ident a) a
     | VarDeclArray (VarDeclId a) a
     -- ^ Multi-dimensional arrays are represented by nested applications of 'VarDeclArray'.
-  deriving (Eq,Show,Read,Typeable,Generic,Data)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
 
 -- | Explicit initializer for a variable declaration.
 data VarInit a
     = InitExp (Exp a) a
     | InitArray (ArrayInit a) a
-  deriving (Eq,Show,Read,Typeable,Generic,Data)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
 
 -- | A formal parameter in method declaration. The last parameter
 --   for a given declaration may be marked as variable arity,
 --   indicated by the boolean argument.
 data FormalParam a = FormalParam [Modifier a] (Type a) Bool (VarDeclId a) a
-  deriving (Eq,Show,Read,Typeable,Generic,Data)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
 
 -- | A method body is either a block of code that implements the method or simply a
 --   semicolon, indicating the lack of an implementation (modelled by 'Nothing').
 data MethodBody a = MethodBody (Maybe (Block a)) a
-  deriving (Eq,Show,Read,Typeable,Generic,Data)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
 
 -- | The first statement of a constructor body may be an explicit invocation of
 --   another constructor of the same class or of the direct superclass.
 data ConstructorBody a = ConstructorBody (Maybe (ExplConstrInv a)) [BlockStmt a] a
-  deriving (Eq,Show,Read,Typeable,Generic,Data)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
 
 -- | An explicit constructor invocation invokes another constructor of the
 --   same class, or a constructor of the direct superclass, which may
@@ -189,7 +188,7 @@ data ExplConstrInv a
     = ThisInvoke             [RefType a] [Argument a] a
     | SuperInvoke            [RefType a] [Argument a] a
     | PrimarySuperInvoke (Exp a) [RefType a] [Argument a] a
-  deriving (Eq,Show,Read,Typeable,Generic,Data)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
 
 
 -- | A modifier specifying properties of a given declaration. In general only
@@ -208,7 +207,7 @@ data Modifier a
     | Native a
     | Annotation (Annotation a) a
     | Synchronized_ a
-  deriving (Eq,Read,Typeable,Generic,Data)
+  deriving (Eq,Read,Typeable,Generic,Data, Functor)
 
 instance Show a => Show (Modifier a) where
    show (Public _) = "public"
@@ -236,7 +235,7 @@ data Annotation a = NormalAnnotation        { annName :: Name a-- Not type becau
                   | MarkerAnnotation        { annName :: Name a
                                             , srcInfo :: a}
 
-  deriving (Eq,Show,Read,Typeable,Generic,Data)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
 
 
 desugarAnnotation :: Annotation a -> (Name a, [(Ident a, ElementValue a)], a)
@@ -251,7 +250,7 @@ desugarAnnotation' = uncurry3 NormalAnnotation . desugarAnnotation
 -- | Annotations may contain  annotations or (loosely) expressions
 data ElementValue a = EVVal (VarInit a) a
                   | EVAnn (Annotation a) a
-  deriving (Eq,Show,Read,Typeable,Generic,Data)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
 
 evInfo :: ElementValue a -> a
 evInfo (EVVal _ a) = a
@@ -262,7 +261,7 @@ evInfo (EVAnn _ a) = a
 -- | A block is a sequence of statements, local class declarations
 --   and local variable declaration statements within braces.
 data Block a = Block [BlockStmt a] a
-  deriving (Eq,Show,Read,Typeable,Generic,Data)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
 
 
 
@@ -272,7 +271,7 @@ data BlockStmt a
     = BlockStmt (Stmt a) a
     | LocalClass (ClassDecl a) a
     | LocalVars [Modifier a] (Type a) [VarDecl a] a
-  deriving (Eq,Show,Read,Typeable,Generic,Data)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
 
 
 -- | A Java statement.
@@ -322,30 +321,30 @@ data Stmt a
     | Try (Block a) [Catch a] (Maybe {- finally -} (Block a)) a
     -- | Statements may have label prefixes.
     | Labeled (Ident a) (Stmt a) a
-  deriving (Eq,Show,Read,Typeable,Generic,Data)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
 
 -- | If a value is thrown and the try statement has one or more catch clauses that can catch it, then control will be
 --   transferred to the first such catch clause.
 data Catch a = Catch (FormalParam a) (Block a) a
-  deriving (Eq,Show,Read,Typeable,Generic,Data)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
 
 -- | A block of code labelled with a @case@ or @default@ within a @switch@ statement.
 data SwitchBlock a
     = SwitchBlock (SwitchLabel a) [BlockStmt a] a
-  deriving (Eq,Show,Read,Typeable,Generic,Data)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
 
 -- | A label within a @switch@ statement.
 data SwitchLabel a
     -- | The expression contained in the @case@ must be a 'Lit' or an @enum@ constant.
     = SwitchCase (Exp a) a
     | Default a
-  deriving (Eq,Show,Read,Typeable,Generic,Data)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
 
 -- | Initialization code for a basic @for@ statement.
 data ForInit a
     = ForLocalVars [Modifier a] (Type a) [VarDecl a] a
     | ForInitExps [Exp a] a
-  deriving (Eq,Show,Read,Typeable,Generic,Data)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
 
 -- | An exception type has to be a class type or a type variable.
 type ExceptionType a = RefType a -- restricted to ClassType or TypeVariable
@@ -422,7 +421,7 @@ data Exp a
     | Lambda (LambdaParams a) (LambdaExpression a) a
     -- | Method reference
     | MethodRef (Name a) (Ident a) a
-  deriving (Eq,Show,Read,Typeable,Generic,Data)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
 
 -- | The left-hand side of an assignment expression. This operand may be a named variable, such as a local
 --   variable or a field of the current object or class, or it may be a computed variable, as can result from
@@ -431,11 +430,11 @@ data Lhs a
     = NameLhs (Name a) a          -- ^ Assign to a variable
     | FieldLhs (FieldAccess a) a  -- ^ Assign through a field access
     | ArrayLhs (ArrayIndex a) a   -- ^ Assign to an array
-  deriving (Eq,Show,Read,Typeable,Generic,Data)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
 
 -- | Array access
 data ArrayIndex a = ArrayIndex (Exp a) [Exp a] a    -- ^ Index into an array
-  deriving (Eq,Show,Read,Typeable,Generic,Data)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
 
 -- | A field access expression may access a field of an object or array, a reference to which is the value
 --   of either an expression or the special keyword super.
@@ -443,7 +442,7 @@ data FieldAccess a
     = PrimaryFieldAccess (Exp a) (Ident a) a      -- ^ Accessing a field of an object or array computed from an expression.
     | SuperFieldAccess (Ident a) a            -- ^ Accessing a field of the superclass.
     | ClassFieldAccess (Name a) (Ident a) a       -- ^ Accessing a (static) field of a named class.
-  deriving (Eq,Show,Read,Typeable,Generic,Data)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
 
 
 -- ¦ A lambda parameter can be a single parameter, or mulitple formal or mulitple inferred parameters
@@ -451,13 +450,13 @@ data LambdaParams a
   = LambdaSingleParam (Ident a) a
   | LambdaFormalParams [FormalParam a] a
   | LambdaInferredParams [Ident a] a
-    deriving (Eq,Show,Read,Typeable,Generic,Data)
+    deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
 
 -- | Lambda expression, starting from java 8
 data LambdaExpression a
     = LambdaExpression (Exp a) a
     | LambdaBlock (Block a) a
-  deriving (Eq,Show,Read,Typeable,Generic,Data)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
 
 
 -- | A method invocation expression is used to invoke a class or instance method.
@@ -472,10 +471,10 @@ data MethodInvocation a
     | ClassMethodCall (Name a) [RefType a] (Ident a) [Argument a] a
     -- | Invoking a method of a named type, giving arguments for any generic type parameters.
     | TypeMethodCall  (Name a) [RefType a] (Ident a) [Argument a] a
-  deriving (Eq,Show,Read,Typeable,Generic,Data)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
 
 -- | An array initializer may be specified in a declaration, or as part of an array creation expression, creating an
 --   array and providing some initial values
 data ArrayInit a
     = ArrayInit [VarInit a] a
-  deriving (Eq,Show,Read,Typeable,Generic,Data)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)

--- a/Language/Java/Syntax.hs
+++ b/Language/Java/Syntax.hs
@@ -57,12 +57,12 @@ import Language.Java.Syntax.Exp
 
 
 -- | A compilation unit is the top level syntactic goal symbol of a Java program.
-data CompilationUnit a = CompilationUnit (Maybe PackageDecl) [ImportDecl] [TypeDecl] a
+data CompilationUnit a = CompilationUnit (Maybe (PackageDecl a)) [ImportDecl] [TypeDecl] a
   deriving (Eq,Show,Read,Typeable,Generic,Data)
 
 
 -- | A package declaration appears within a compilation unit to indicate the package to which the compilation unit belongs.
-newtype PackageDecl = PackageDecl Name
+data PackageDecl a = PackageDecl Name a
   deriving (Eq,Show,Read,Typeable,Generic,Data)
 
 -- | An import declaration allows a static member or a named type to be referred to by a single unqualified identifier.

--- a/Language/Java/Syntax.hs
+++ b/Language/Java/Syntax.hs
@@ -47,6 +47,7 @@ module Language.Java.Syntax
     ) where
 
 import Data.Data
+import Data.Tuple.Extra
 import GHC.Generics (Generic)
 
 import Language.Java.Syntax.Types
@@ -57,20 +58,20 @@ import Language.Java.Syntax.Exp
 
 
 -- | A compilation unit is the top level syntactic goal symbol of a Java program.
-data CompilationUnit a = CompilationUnit (Maybe (PackageDecl a)) [ImportDecl] [TypeDecl] a
+data CompilationUnit a = CompilationUnit (Maybe (PackageDecl a)) [ImportDecl a] [TypeDecl a] a
   deriving (Eq,Show,Read,Typeable,Generic,Data)
 
 
 -- | A package declaration appears within a compilation unit to indicate the package to which the compilation unit belongs.
-data PackageDecl a = PackageDecl Name a
+data PackageDecl a = PackageDecl (Name a) a
   deriving (Eq,Show,Read,Typeable,Generic,Data)
 
 -- | An import declaration allows a static member or a named type to be referred to by a single unqualified identifier.
 --   The first argument signals whether the declaration only imports static members.
 --   The last argument signals whether the declaration brings all names in the named type or package, or only brings
 --   a single name into scope.
-data ImportDecl
-    = ImportDecl Bool {- static? -} Name Bool {- .*? -}
+data ImportDecl a
+    = ImportDecl Bool {- static? -} (Name a) Bool {- .*? -} a
   deriving (Eq,Show,Read,Typeable,Generic,Data)
 
 
@@ -78,38 +79,38 @@ data ImportDecl
 -- Declarations
 
 -- | A type declaration declares a class type or an interface type.
-data TypeDecl
-    = ClassTypeDecl ClassDecl
-    | InterfaceTypeDecl InterfaceDecl
+data TypeDecl a
+    = ClassTypeDecl (ClassDecl a) a
+    | InterfaceTypeDecl (InterfaceDecl a) a
   deriving (Eq,Show,Read,Typeable,Generic,Data)
 
 -- | A class declaration specifies a new named reference type.
-data ClassDecl
-    = ClassDecl [Modifier] Ident [TypeParam] (Maybe RefType) [RefType] ClassBody
-    | EnumDecl  [Modifier] Ident                             [RefType] EnumBody
+data ClassDecl a
+    = ClassDecl [Modifier a] (Ident a) [TypeParam a] (Maybe (RefType a)) [RefType a] (ClassBody a) a
+    | EnumDecl  [Modifier a] (Ident a)                             [RefType a] (EnumBody a) a
   deriving (Eq,Show,Read,Typeable,Generic,Data)
 
 -- | A class body may contain declarations of members of the class, that is,
 --   fields, classes, interfaces and methods.
 --   A class body may also contain instance initializers, static
 --   initializers, and declarations of constructors for the class.
-newtype ClassBody = ClassBody [Decl]
+data ClassBody a = ClassBody [Decl a] a
   deriving (Eq,Show,Read,Typeable,Generic,Data)
 
 -- | The body of an enum type may contain enum constants.
-data EnumBody = EnumBody [EnumConstant] [Decl]
+data EnumBody a = EnumBody [EnumConstant a] [Decl a] a
   deriving (Eq,Show,Read,Typeable,Generic,Data)
 
 -- | An enum constant defines an instance of the enum type.
-data EnumConstant = EnumConstant Ident [Argument] (Maybe ClassBody)
+data EnumConstant a = EnumConstant (Ident a) [Argument a] (Maybe (ClassBody a)) a
   deriving (Eq,Show,Read,Typeable,Generic,Data)
 
 -- | An interface declaration introduces a new reference type whose members
 --   are classes, interfaces, constants and abstract methods. This type has
 --   no implementation, but otherwise unrelated classes can implement it by
 --   providing implementations for its abstract methods.
-data InterfaceDecl
-    = InterfaceDecl InterfaceKind [Modifier] Ident [TypeParam] [RefType] InterfaceBody
+data InterfaceDecl a
+    = InterfaceDecl InterfaceKind [Modifier a] (Ident a) [TypeParam a] [RefType a] (InterfaceBody a) a
   deriving (Eq,Show,Read,Typeable,Generic,Data)
 
 -- | Interface can declare either a normal interface or an annotation
@@ -117,350 +118,364 @@ data InterfaceKind = InterfaceNormal | InterfaceAnnotation
   deriving (Eq,Show,Read,Typeable,Generic,Data)
 
 -- | The body of an interface may declare members of the interface.
-newtype InterfaceBody
-    = InterfaceBody [MemberDecl]
+data InterfaceBody a
+    = InterfaceBody [MemberDecl a] a
   deriving (Eq,Show,Read,Typeable,Generic,Data)
 
 -- | A declaration is either a member declaration, or a declaration of an
 --   initializer, which may be static.
-data Decl
-    = MemberDecl MemberDecl
-    | InitDecl Bool Block
+data Decl a
+    = MemberDecl (MemberDecl a) a
+    | InitDecl Bool (Block a) a
   deriving (Eq,Show,Read,Typeable,Generic,Data)
 
 
 -- | A class or interface member can be an inner class or interface, a field or
 --   constant, or a method or constructor. An interface may only have as members
 --   constants (not fields), abstract methods, and no constructors.
-data MemberDecl
+data MemberDecl a
     -- | The variables of a class type are introduced by field declarations.
-    = FieldDecl [Modifier] Type [VarDecl]
+    = FieldDecl [Modifier a] (Type a) [VarDecl a] a
     -- | A method declares executable code that can be invoked, passing a fixed number of values as arguments.
-    | MethodDecl      [Modifier] [TypeParam] (Maybe Type) Ident [FormalParam] [ExceptionType] (Maybe Exp) MethodBody
+    | MethodDecl      [Modifier a] [TypeParam a] (Maybe (Type a)) (Ident a) [FormalParam a] [ExceptionType a] (Maybe (Exp a)) (MethodBody a) a
     -- | A constructor is used in the creation of an object that is an instance of a class.
-    | ConstructorDecl [Modifier] [TypeParam]              Ident [FormalParam] [ExceptionType] ConstructorBody
+    | ConstructorDecl [Modifier a] [TypeParam a]              (Ident a) [FormalParam a] [ExceptionType a] (ConstructorBody a) a
     -- | A member class is a class whose declaration is directly enclosed in another class or interface declaration.
-    | MemberClassDecl ClassDecl
+    | MemberClassDecl (ClassDecl a) a
     -- | A member interface is an interface whose declaration is directly enclosed in another class or interface declaration.
-    | MemberInterfaceDecl InterfaceDecl
+    | MemberInterfaceDecl (InterfaceDecl a) a
   deriving (Eq,Show,Read,Typeable,Generic,Data)
 
 
 -- | A declaration of a variable, which may be explicitly initialized.
-data VarDecl
-    = VarDecl VarDeclId (Maybe VarInit)
+data VarDecl a
+    = VarDecl (VarDeclId a) (Maybe (VarInit a)) a
   deriving (Eq,Show,Read,Typeable,Generic,Data)
 
 -- | The name of a variable in a declaration, which may be an array.
-data VarDeclId
-    = VarId Ident
-    | VarDeclArray VarDeclId
+data VarDeclId a
+    = VarId (Ident a) a
+    | VarDeclArray (VarDeclId a) a
     -- ^ Multi-dimensional arrays are represented by nested applications of 'VarDeclArray'.
   deriving (Eq,Show,Read,Typeable,Generic,Data)
 
 -- | Explicit initializer for a variable declaration.
-data VarInit
-    = InitExp Exp
-    | InitArray ArrayInit
+data VarInit a
+    = InitExp (Exp a) a
+    | InitArray (ArrayInit a) a
   deriving (Eq,Show,Read,Typeable,Generic,Data)
 
 -- | A formal parameter in method declaration. The last parameter
 --   for a given declaration may be marked as variable arity,
 --   indicated by the boolean argument.
-data FormalParam = FormalParam [Modifier] Type Bool VarDeclId
+data FormalParam a = FormalParam [Modifier a] (Type a) Bool (VarDeclId a) a
   deriving (Eq,Show,Read,Typeable,Generic,Data)
 
 -- | A method body is either a block of code that implements the method or simply a
 --   semicolon, indicating the lack of an implementation (modelled by 'Nothing').
-newtype MethodBody = MethodBody (Maybe Block)
+data MethodBody a = MethodBody (Maybe (Block a)) a
   deriving (Eq,Show,Read,Typeable,Generic,Data)
 
 -- | The first statement of a constructor body may be an explicit invocation of
 --   another constructor of the same class or of the direct superclass.
-data ConstructorBody = ConstructorBody (Maybe ExplConstrInv) [BlockStmt]
+data ConstructorBody a = ConstructorBody (Maybe (ExplConstrInv a)) [BlockStmt a] a
   deriving (Eq,Show,Read,Typeable,Generic,Data)
 
 -- | An explicit constructor invocation invokes another constructor of the
 --   same class, or a constructor of the direct superclass, which may
 --   be qualified to explicitly specify the newly created object's immediately
 --   enclosing instance.
-data ExplConstrInv
-    = ThisInvoke             [RefType] [Argument]
-    | SuperInvoke            [RefType] [Argument]
-    | PrimarySuperInvoke Exp [RefType] [Argument]
+data ExplConstrInv a
+    = ThisInvoke             [RefType a] [Argument a] a
+    | SuperInvoke            [RefType a] [Argument a] a
+    | PrimarySuperInvoke (Exp a) [RefType a] [Argument a] a
   deriving (Eq,Show,Read,Typeable,Generic,Data)
 
 
 -- | A modifier specifying properties of a given declaration. In general only
 --   a few of these modifiers are allowed for each declaration type, for instance
 --   a member type declaration may only specify one of public, private or protected.
-data Modifier
-    = Public
-    | Private
-    | Protected
-    | Abstract
-    | Final
-    | Static
-    | StrictFP
-    | Transient
-    | Volatile
-    | Native
-    | Annotation Annotation
-    | Synchronized_
+data Modifier a
+    = Public a
+    | Private a
+    | Protected a
+    | Abstract a
+    | Final a
+    | Static a
+    | StrictFP a
+    | Transient a
+    | Volatile a
+    | Native a
+    | Annotation (Annotation a) a
+    | Synchronized_ a
   deriving (Eq,Read,Typeable,Generic,Data)
 
-instance Show Modifier where
-   show Public = "public" 
-   show Private = "private"
-   show Protected = "protected"
-   show Abstract = "abstract"
-   show Final = "final"
-   show Static = "static"
-   show StrictFP = "strictfp"
-   show Transient = "transient"
-   show Volatile = "volatile"
-   show Native = "native"
-   show (Annotation a) = show a
-   show Synchronized_ = "synchronized"
+instance Show a => Show (Modifier a) where
+   show (Public _) = "public"
+   show (Private _) = "private"
+   show (Protected _)  = "protected"
+   show (Abstract _) = "abstract"
+   show (Final _) = "final"
+   show (Static _) = "static"
+   show (StrictFP _) = "strictfp"
+   show (Transient _) = "transient"
+   show (Volatile _) = "volatile"
+   show (Native _) = "native"
+   show (Annotation a _) = show a
+   show (Synchronized_ _) = "synchronized"
 
 -- | Annotations have three different forms: no-parameter, single-parameter or key-value pairs
-data Annotation = NormalAnnotation        { annName :: Name -- Not type because not type generics not allowed
-                                          , annKV   :: [(Ident, ElementValue)] }
-                | SingleElementAnnotation { annName :: Name
-                                          , annValue:: ElementValue }
-                | MarkerAnnotation        { annName :: Name }
+data Annotation a = NormalAnnotation        { annName :: Name a-- Not type because not type generics not allowed
+                                            , annKV   :: [(Ident a, ElementValue a)]
+                                            , srcInfo :: a }
+
+                  | SingleElementAnnotation { annName :: Name a
+                                            , annValue:: ElementValue a
+                                            , srcInfo :: a }
+
+                  | MarkerAnnotation        { annName :: Name a
+                                            , srcInfo :: a}
+
   deriving (Eq,Show,Read,Typeable,Generic,Data)
 
-desugarAnnotation (MarkerAnnotation n)          = (n, [])
-desugarAnnotation (SingleElementAnnotation n e) = (n, [(Ident "value", e)])
-desugarAnnotation (NormalAnnotation n kv)       = (n, kv)
-desugarAnnotation' = uncurry NormalAnnotation . desugarAnnotation
+
+desugarAnnotation :: Annotation a -> (Name a, [(Ident a, ElementValue a)], a)
+desugarAnnotation (MarkerAnnotation n a)          = (n, [], a)
+desugarAnnotation (SingleElementAnnotation n e a) = (n, [(Ident "value" (evInfo e), e)], a)
+desugarAnnotation (NormalAnnotation n kv a)       = (n, kv, a)
+
+desugarAnnotation' :: Annotation a -> Annotation a
+desugarAnnotation' = uncurry3 NormalAnnotation . desugarAnnotation
+
 
 -- | Annotations may contain  annotations or (loosely) expressions
-data ElementValue = EVVal VarInit
-                  | EVAnn Annotation
+data ElementValue a = EVVal (VarInit a) a
+                  | EVAnn (Annotation a) a
   deriving (Eq,Show,Read,Typeable,Generic,Data)
 
+evInfo :: ElementValue a -> a
+evInfo (EVVal _ a) = a
+evInfo (EVAnn _ a) = a
 -----------------------------------------------------------------------
 -- Statements
 
 -- | A block is a sequence of statements, local class declarations
 --   and local variable declaration statements within braces.
-data Block = Block [BlockStmt]
+data Block a = Block [BlockStmt a] a
   deriving (Eq,Show,Read,Typeable,Generic,Data)
 
 
 
 -- | A block statement is either a normal statement, a local
 --   class declaration or a local variable declaration.
-data BlockStmt
-    = BlockStmt Stmt
-    | LocalClass ClassDecl
-    | LocalVars [Modifier] Type [VarDecl]
+data BlockStmt a
+    = BlockStmt (Stmt a) a
+    | LocalClass (ClassDecl a) a
+    | LocalVars [Modifier a] (Type a) [VarDecl a] a
   deriving (Eq,Show,Read,Typeable,Generic,Data)
 
 
 -- | A Java statement.
-data Stmt
+data Stmt a
     -- | A statement can be a nested block.
-    = StmtBlock Block
+    = StmtBlock (Block a) a
     -- | The @if-then@ statement allows conditional execution of a statement.
-    | IfThen Exp Stmt
+    | IfThen (Exp a) (Stmt a) a
     -- | The @if-then-else@ statement allows conditional choice of two statements, executing one or the other but not both.
-    | IfThenElse Exp Stmt Stmt
+    | IfThenElse (Exp a) (Stmt a) (Stmt a) a
     -- | The @while@ statement executes an expression and a statement repeatedly until the value of the expression is false.
-    | While Exp Stmt
+    | While (Exp a) (Stmt a) a
     -- | The basic @for@ statement executes some initialization code, then executes an expression, a statement, and some
     --   update code repeatedly until the value of the expression is false.
-    | BasicFor (Maybe ForInit) (Maybe Exp) (Maybe [Exp]) Stmt
+    | BasicFor (Maybe (ForInit a)) (Maybe (Exp a)) (Maybe [Exp a]) (Stmt a) a
     -- | The enhanced @for@ statement iterates over an array or a value of a class that implements the @iterator@ interface.
-    | EnhancedFor [Modifier] Type Ident Exp Stmt
+    | EnhancedFor [Modifier a] (Type a) (Ident a) (Exp a) (Stmt a) a
     -- | An empty statement does nothing.
-    | Empty
+    | Empty a
     -- | Certain kinds of expressions may be used as statements by following them with semicolons:
     --   assignments, pre- or post-inc- or decrementation, method invocation or class instance
     --   creation expressions.
-    | ExpStmt Exp
+    | ExpStmt (Exp a) a
     -- | An assertion is a statement containing a boolean expression, where an error is reported if the expression
     --   evaluates to false.
-    | Assert Exp (Maybe Exp)
+    | Assert (Exp a) (Maybe (Exp a)) a
     -- | The switch statement transfers control to one of several statements depending on the value of an expression.
-    | Switch Exp [SwitchBlock]
+    | Switch (Exp a) [SwitchBlock a] a
     -- | The @do@ statement executes a statement and an expression repeatedly until the value of the expression is false.
-    | Do Stmt Exp
+    | Do (Stmt a) (Exp a) a
     -- | A @break@ statement transfers control out of an enclosing statement.
-    | Break (Maybe Ident)
+    | Break (Maybe (Ident a)) a
     -- | A @continue@ statement may occur only in a while, do, or for statement. Control passes to the loop-continuation
     --   point of that statement.
-    | Continue (Maybe Ident)
+    | Continue (Maybe (Ident a)) a
     -- A @return@ statement returns control to the invoker of a method or constructor.
-    | Return (Maybe Exp)
+    | Return (Maybe (Exp a)) a
     -- | A @synchronized@ statement acquires a mutual-exclusion lock on behalf of the executing thread, executes a block,
     --   then releases the lock. While the executing thread owns the lock, no other thread may acquire the lock.
-    | Synchronized Exp Block
+    | Synchronized (Exp a) (Block a) a
     -- | A @throw@ statement causes an exception to be thrown.
-    | Throw Exp
+    | Throw (Exp a) a
     -- | A try statement executes a block. If a value is thrown and the try statement has one or more catch clauses that
     --   can catch it, then control will be transferred to the first such catch clause. If the try statement has a finally
     --   clause, then another block of code is executed, no matter whether the try block completes normally or abruptly,
     --   and no matter whether a catch clause is first given control.
-    | Try Block [Catch] (Maybe {- finally -} Block)
+    | Try (Block a) [Catch a] (Maybe {- finally -} (Block a)) a
     -- | Statements may have label prefixes.
-    | Labeled Ident Stmt
+    | Labeled (Ident a) (Stmt a) a
   deriving (Eq,Show,Read,Typeable,Generic,Data)
 
 -- | If a value is thrown and the try statement has one or more catch clauses that can catch it, then control will be
 --   transferred to the first such catch clause.
-data Catch = Catch FormalParam Block
+data Catch a = Catch (FormalParam a) (Block a) a
   deriving (Eq,Show,Read,Typeable,Generic,Data)
 
 -- | A block of code labelled with a @case@ or @default@ within a @switch@ statement.
-data SwitchBlock
-    = SwitchBlock SwitchLabel [BlockStmt]
+data SwitchBlock a
+    = SwitchBlock (SwitchLabel a) [BlockStmt a] a
   deriving (Eq,Show,Read,Typeable,Generic,Data)
 
 -- | A label within a @switch@ statement.
-data SwitchLabel
+data SwitchLabel a
     -- | The expression contained in the @case@ must be a 'Lit' or an @enum@ constant.
-    = SwitchCase Exp
-    | Default
+    = SwitchCase (Exp a) a
+    | Default a
   deriving (Eq,Show,Read,Typeable,Generic,Data)
 
 -- | Initialization code for a basic @for@ statement.
-data ForInit
-    = ForLocalVars [Modifier] Type [VarDecl]
-    | ForInitExps [Exp]
+data ForInit a
+    = ForLocalVars [Modifier a] (Type a) [VarDecl a] a
+    | ForInitExps [Exp a] a
   deriving (Eq,Show,Read,Typeable,Generic,Data)
 
 -- | An exception type has to be a class type or a type variable.
-type ExceptionType = RefType -- restricted to ClassType or TypeVariable
+type ExceptionType a = RefType a -- restricted to ClassType or TypeVariable
 
 -- | Arguments to methods and constructors are expressions.
-type Argument = Exp
+type Argument a = Exp a
 
 -- | A Java expression.
-data Exp
+data Exp a
     -- | A literal denotes a fixed, unchanging value.
-    = Lit Literal
+    = Lit (Literal a) a
     -- | A class literal, which is an expression consisting of the name of a class, interface, array,
     --   or primitive type, or the pseudo-type void (modelled by 'Nothing'), followed by a `.' and the token class.
-    | ClassLit (Maybe Type)
+    | ClassLit (Maybe (Type a)) a
     -- | The keyword @this@ denotes a value that is a reference to the object for which the instance method
     --   was invoked, or to the object being constructed.
-    | This
+    | This a
     -- | Any lexically enclosing instance can be referred to by explicitly qualifying the keyword this.
-    | ThisClass Name
+    | ThisClass (Name a) a
     -- | A class instance creation expression is used to create new objects that are instances of classes.
     -- | The first argument is a list of non-wildcard type arguments to a generic constructor.
     --   What follows is the type to be instantiated, the list of arguments passed to the constructor, and
     --   optionally a class body that makes the constructor result in an object of an /anonymous/ class.
-    | InstanceCreation [TypeArgument] TypeDeclSpecifier [Argument] (Maybe ClassBody)
+    | InstanceCreation [TypeArgument a] (TypeDeclSpecifier a) [Argument a] (Maybe (ClassBody a)) a
     -- | A qualified class instance creation expression enables the creation of instances of inner member classes
     --   and their anonymous subclasses.
-    | QualInstanceCreation Exp [TypeArgument] Ident [Argument] (Maybe ClassBody)
+    | QualInstanceCreation (Exp a) [TypeArgument a] (Ident a) [Argument a] (Maybe (ClassBody a)) a
     -- | An array instance creation expression is used to create new arrays. The last argument denotes the number
     --   of dimensions that have no explicit length given. These dimensions must be given last.
-    | ArrayCreate Type [Exp] Int
+    | ArrayCreate (Type a) [Exp a] Int a
     -- | An array instance creation expression may come with an explicit initializer. Such expressions may not
     --   be given explicit lengths for any of its dimensions.
-    | ArrayCreateInit Type Int ArrayInit
+    | ArrayCreateInit (Type a) Int (ArrayInit a) a
     -- | A field access expression.
-    | FieldAccess FieldAccess
+    | FieldAccess (FieldAccess a) a
     -- | A method invocation expression.
-    | MethodInv MethodInvocation
+    | MethodInv (MethodInvocation a) a
     -- | An array access expression refers to a variable that is a component of an array.
-    | ArrayAccess ArrayIndex
+    | ArrayAccess (ArrayIndex a) a
 {-    | ArrayAccess Exp Exp -- Should this be made into a datatype, for consistency and use with Lhs? -}
     -- | An expression name, e.g. a variable.
-    | ExpName Name
+    | ExpName (Name a) a
     -- | Post-incrementation expression, i.e. an expression followed by @++@.
-    | PostIncrement Exp
+    | PostIncrement (Exp a) a
     -- | Post-decrementation expression, i.e. an expression followed by @--@.
-    | PostDecrement Exp
+    | PostDecrement (Exp a) a
     -- | Pre-incrementation expression, i.e. an expression preceded by @++@.
-    | PreIncrement  Exp
+    | PreIncrement  (Exp a) a
     -- | Pre-decrementation expression, i.e. an expression preceded by @--@.
-    | PreDecrement  Exp
+    | PreDecrement  (Exp a) a
     -- | Unary plus, the promotion of the value of the expression to a primitive numeric type.
-    | PrePlus  Exp
+    | PrePlus  (Exp a) a
     -- | Unary minus, the promotion of the negation of the value of the expression to a primitive numeric type.
-    | PreMinus Exp
+    | PreMinus (Exp a) a
     -- | Unary bitwise complementation: note that, in all cases, @~x@ equals @(-x)-1@.
-    | PreBitCompl Exp
+    | PreBitCompl (Exp a) a
     -- | Logical complementation of boolean values.
-    | PreNot  Exp
+    | PreNot  (Exp a) a
     -- | A cast expression converts, at run time, a value of one numeric type to a similar value of another
     --   numeric type; or confirms, at compile time, that the type of an expression is boolean; or checks,
     --   at run time, that a reference value refers to an object whose class is compatible with a specified
     --   reference type.
-    | Cast  Type Exp
+    | Cast  (Type a) (Exp a) a
     -- | The application of a binary operator to two operand expressions.
-    | BinOp Exp Op Exp
+    | BinOp (Exp a) (Op a) (Exp a) a
     -- | Testing whether the result of an expression is an instance of some reference type.
-    | InstanceOf Exp RefType
+    | InstanceOf (Exp a) (RefType a) a
     -- | The conditional operator @? :@ uses the boolean value of one expression to decide which of two other
     --   expressions should be evaluated.
-    | Cond Exp Exp Exp
+    | Cond (Exp a) (Exp a) (Exp a) a
     -- | Assignment of the result of an expression to a variable.
-    | Assign Lhs AssignOp Exp
+    | Assign (Lhs a) (AssignOp a) (Exp a) a
     -- | Lambda expression
-    | Lambda LambdaParams LambdaExpression
+    | Lambda (LambdaParams a) (LambdaExpression a) a
     -- | Method reference
-    | MethodRef Name Ident
+    | MethodRef (Name a) (Ident a) a
   deriving (Eq,Show,Read,Typeable,Generic,Data)
 
 -- | The left-hand side of an assignment expression. This operand may be a named variable, such as a local
 --   variable or a field of the current object or class, or it may be a computed variable, as can result from
 --   a field access or an array access.
-data Lhs
-    = NameLhs Name          -- ^ Assign to a variable
-    | FieldLhs FieldAccess  -- ^ Assign through a field access
-    | ArrayLhs ArrayIndex   -- ^ Assign to an array
+data Lhs a
+    = NameLhs (Name a) a          -- ^ Assign to a variable
+    | FieldLhs (FieldAccess a) a  -- ^ Assign through a field access
+    | ArrayLhs (ArrayIndex a) a   -- ^ Assign to an array
   deriving (Eq,Show,Read,Typeable,Generic,Data)
 
 -- | Array access
-data ArrayIndex = ArrayIndex Exp [Exp]    -- ^ Index into an array
+data ArrayIndex a = ArrayIndex (Exp a) [Exp a] a    -- ^ Index into an array
   deriving (Eq,Show,Read,Typeable,Generic,Data)
 
 -- | A field access expression may access a field of an object or array, a reference to which is the value
 --   of either an expression or the special keyword super.
-data FieldAccess
-    = PrimaryFieldAccess Exp Ident      -- ^ Accessing a field of an object or array computed from an expression.
-    | SuperFieldAccess Ident            -- ^ Accessing a field of the superclass.
-    | ClassFieldAccess Name Ident       -- ^ Accessing a (static) field of a named class.
+data FieldAccess a
+    = PrimaryFieldAccess (Exp a) (Ident a) a      -- ^ Accessing a field of an object or array computed from an expression.
+    | SuperFieldAccess (Ident a) a            -- ^ Accessing a field of the superclass.
+    | ClassFieldAccess (Name a) (Ident a) a       -- ^ Accessing a (static) field of a named class.
   deriving (Eq,Show,Read,Typeable,Generic,Data)
 
 
 -- ¦ A lambda parameter can be a single parameter, or mulitple formal or mulitple inferred parameters
-data LambdaParams
-  = LambdaSingleParam Ident
-  | LambdaFormalParams [FormalParam]
-  | LambdaInferredParams [Ident]
+data LambdaParams a
+  = LambdaSingleParam (Ident a) a
+  | LambdaFormalParams [FormalParam a] a
+  | LambdaInferredParams [Ident a] a
     deriving (Eq,Show,Read,Typeable,Generic,Data)
 
 -- | Lambda expression, starting from java 8
-data LambdaExpression
-    = LambdaExpression Exp
-    | LambdaBlock Block
+data LambdaExpression a
+    = LambdaExpression (Exp a) a
+    | LambdaBlock (Block a) a
   deriving (Eq,Show,Read,Typeable,Generic,Data)
 
 
 -- | A method invocation expression is used to invoke a class or instance method.
-data MethodInvocation
+data MethodInvocation a
     -- | Invoking a specific named method.
-    = MethodCall Name [Argument]
+    = MethodCall (Name a) [Argument a] a
     -- | Invoking a method of a class computed from a primary expression, giving arguments for any generic type parameters.
-    | PrimaryMethodCall Exp [RefType] Ident [Argument]
+    | PrimaryMethodCall (Exp a) [RefType a] (Ident a) [Argument a] a
     -- | Invoking a method of the super class, giving arguments for any generic type parameters.
-    | SuperMethodCall [RefType] Ident [Argument]
+    | SuperMethodCall [RefType a] (Ident a) [Argument a] a
     -- | Invoking a method of the superclass of a named class, giving arguments for any generic type parameters.
-    | ClassMethodCall Name [RefType] Ident [Argument]
+    | ClassMethodCall (Name a) [RefType a] (Ident a) [Argument a] a
     -- | Invoking a method of a named type, giving arguments for any generic type parameters.
-    | TypeMethodCall  Name [RefType] Ident [Argument]
+    | TypeMethodCall  (Name a) [RefType a] (Ident a) [Argument a] a
   deriving (Eq,Show,Read,Typeable,Generic,Data)
 
 -- | An array initializer may be specified in a declaration, or as part of an array creation expression, creating an
 --   array and providing some initial values
-data ArrayInit
-    = ArrayInit [VarInit]
+data ArrayInit a
+    = ArrayInit [VarInit a] a
   deriving (Eq,Show,Read,Typeable,Generic,Data)

--- a/Language/Java/Syntax.hs
+++ b/Language/Java/Syntax.hs
@@ -47,7 +47,7 @@ module Language.Java.Syntax
     ) where
 
 import Data.Data
-import Data.Tuple.Extra
+import Data.Tuple.Extra (uncurry3)
 import GHC.Generics (Generic)
 
 import Language.Java.Syntax.Types

--- a/Language/Java/Syntax.hs
+++ b/Language/Java/Syntax.hs
@@ -389,21 +389,21 @@ data Exp a
     -- | An expression name, e.g. a variable.
     | ExpName (Name a) a
     -- | Post-incrementation expression, i.e. an expression followed by @++@.
-    | PostIncrement (Exp a) a
+    | PostIncrement a (Exp a)
     -- | Post-decrementation expression, i.e. an expression followed by @--@.
-    | PostDecrement (Exp a) a
+    | PostDecrement a (Exp a)
     -- | Pre-incrementation expression, i.e. an expression preceded by @++@.
-    | PreIncrement  (Exp a) a
+    | PreIncrement  a (Exp a)
     -- | Pre-decrementation expression, i.e. an expression preceded by @--@.
-    | PreDecrement  (Exp a) a
+    | PreDecrement  a (Exp a)
     -- | Unary plus, the promotion of the value of the expression to a primitive numeric type.
-    | PrePlus  (Exp a) a
+    | PrePlus  a (Exp a)
     -- | Unary minus, the promotion of the negation of the value of the expression to a primitive numeric type.
-    | PreMinus (Exp a) a
+    | PreMinus a (Exp a)
     -- | Unary bitwise complementation: note that, in all cases, @~x@ equals @(-x)-1@.
-    | PreBitCompl (Exp a) a
+    | PreBitCompl a (Exp a)
     -- | Logical complementation of boolean values.
-    | PreNot  (Exp a) a
+    | PreNot  a (Exp a)
     -- | A cast expression converts, at run time, a value of one numeric type to a similar value of another
     --   numeric type; or confirms, at compile time, that the type of an expression is boolean; or checks,
     --   at run time, that a reference value refers to an object whose class is compatible with a specified

--- a/Language/Java/Syntax.hs
+++ b/Language/Java/Syntax.hs
@@ -57,7 +57,7 @@ import Language.Java.Syntax.Exp
 
 
 -- | A compilation unit is the top level syntactic goal symbol of a Java program.
-data CompilationUnit = CompilationUnit (Maybe PackageDecl) [ImportDecl] [TypeDecl]
+data CompilationUnit a = CompilationUnit (Maybe PackageDecl) [ImportDecl] [TypeDecl] a
   deriving (Eq,Show,Read,Typeable,Generic,Data)
 
 

--- a/Language/Java/Syntax/Exp.hs
+++ b/Language/Java/Syntax/Exp.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveDataTypeable, DeriveFunctor, DeriveGeneric #-}
+{-# LANGUAGE DeriveDataTypeable, DeriveFunctor, DeriveGeneric, DeriveFoldable, DeriveTraversable #-}
 module Language.Java.Syntax.Exp where
 
 import Data.Data
@@ -14,15 +14,15 @@ data Literal a
     | Char Char a
     | String String a
     | Null a
-  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor, Foldable, Traversable)
 
 -- | A binary infix operator.
 data Op a = Mult a| Div a| Rem a| Add a | Sub a | LShift a | RShift a | RRShift a
         | LThan a | GThan a | LThanE a | GThanE a | Equal a | NotEq a
         | And a| Or a| Xor a| CAnd a| COr a
-  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor, Foldable, Traversable)
 
 -- | An assignment operator.
 data AssignOp a = EqualA a | MultA a | DivA a | RemA a | AddA a | SubA a
               | LShiftA a| RShiftA a| RRShiftA a| AndA a| XorA a| OrA a
-  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor, Foldable, Traversable)

--- a/Language/Java/Syntax/Exp.hs
+++ b/Language/Java/Syntax/Exp.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveDataTypeable, DeriveGeneric #-}
+{-# LANGUAGE DeriveDataTypeable, DeriveFunctor, DeriveGeneric #-}
 module Language.Java.Syntax.Exp where
 
 import Data.Data

--- a/Language/Java/Syntax/Exp.hs
+++ b/Language/Java/Syntax/Exp.hs
@@ -5,24 +5,24 @@ import Data.Data
 import GHC.Generics (Generic)
 
 -- | A literal denotes a fixed, unchanging value.
-data Literal
-    = Int Integer
-    | Word Integer
-    | Float Double
-    | Double Double
-    | Boolean Bool
-    | Char Char
-    | String String
-    | Null
+data Literal a
+    = Int Integer a
+    | Word Integer a
+    | Float Double a
+    | Double Double a
+    | Boolean Bool a
+    | Char Char a
+    | String String a
+    | Null a
   deriving (Eq,Show,Read,Typeable,Generic,Data)
 
 -- | A binary infix operator.
-data Op = Mult | Div | Rem | Add | Sub | LShift | RShift | RRShift
-        | LThan | GThan | LThanE | GThanE | Equal | NotEq
-        | And | Or | Xor | CAnd | COr
+data Op a = Mult a| Div a| Rem a| Add a | Sub a | LShift a | RShift a | RRShift a
+        | LThan a | GThan a | LThanE a | GThanE a | Equal a | NotEq a
+        | And a| Or a| Xor a| CAnd a| COr a
   deriving (Eq,Show,Read,Typeable,Generic,Data)
 
 -- | An assignment operator.
-data AssignOp = EqualA | MultA | DivA | RemA | AddA | SubA
-              | LShiftA | RShiftA | RRShiftA | AndA | XorA | OrA
+data AssignOp a = EqualA a | MultA a | DivA a | RemA a | AddA a | SubA a
+              | LShiftA a| RShiftA a| RRShiftA a| AndA a| XorA a| OrA a
   deriving (Eq,Show,Read,Typeable,Generic,Data)

--- a/Language/Java/Syntax/Exp.hs
+++ b/Language/Java/Syntax/Exp.hs
@@ -14,15 +14,15 @@ data Literal a
     | Char Char a
     | String String a
     | Null a
-  deriving (Eq,Show,Read,Typeable,Generic,Data)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
 
 -- | A binary infix operator.
 data Op a = Mult a| Div a| Rem a| Add a | Sub a | LShift a | RShift a | RRShift a
         | LThan a | GThan a | LThanE a | GThanE a | Equal a | NotEq a
         | And a| Or a| Xor a| CAnd a| COr a
-  deriving (Eq,Show,Read,Typeable,Generic,Data)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
 
 -- | An assignment operator.
 data AssignOp a = EqualA a | MultA a | DivA a | RemA a | AddA a | SubA a
               | LShiftA a| RShiftA a| RRShiftA a| AndA a| XorA a| OrA a
-  deriving (Eq,Show,Read,Typeable,Generic,Data)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)

--- a/Language/Java/Syntax/Types.hs
+++ b/Language/Java/Syntax/Types.hs
@@ -43,8 +43,8 @@ data Diamond a = Diamond a
 
 -- | Wildcards may be given explicit bounds, either upper (@extends@) or lower (@super@) bounds.
 data WildcardBound a
-    = ExtendsBound (RefType a) a
-    | SuperBound (RefType a) a
+    = ExtendsBound a (RefType a)
+    | SuperBound a (RefType a)
   deriving (Eq,Show,Read,Typeable,Generic,Data)
 
 -- | A primitive type is predefined by the Java programming language and named by its reserved keyword.

--- a/Language/Java/Syntax/Types.hs
+++ b/Language/Java/Syntax/Types.hs
@@ -23,7 +23,7 @@ data RefType a
 -- | A class or interface type consists of a type declaration specifier,
 --   optionally followed by type arguments (in which case it is a parameterized type).
 data ClassType a
-    = ClassType [(Ident a, [TypeArgument a])] a
+    = ClassType a [(Ident a, [TypeArgument a])]
   deriving (Eq,Show,Read,Typeable,Generic,Data)
 
 -- | Type arguments may be either reference types or wildcards.

--- a/Language/Java/Syntax/Types.hs
+++ b/Language/Java/Syntax/Types.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveDataTypeable, DeriveGeneric #-}
+{-# LANGUAGE DeriveDataTypeable, DeriveGeneric, DeriveFunctor #-}
 module Language.Java.Syntax.Types where
 
 import Data.Data
@@ -8,7 +8,7 @@ import GHC.Generics (Generic)
 data Type a
     = PrimType (PrimType a) a
     | RefType (RefType a) a
-  deriving (Eq,Show,Read,Typeable,Generic,Data)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
 
 -- | There are three kinds of reference types: class types, interface types, and array types.
 --   Reference types may be parameterized with type arguments.
@@ -18,34 +18,34 @@ data RefType a
     = ClassRefType (ClassType a) a
     {- | TypeVariable Ident -}
     | ArrayType (Type a) a
-  deriving (Eq,Show,Read,Typeable,Generic,Data)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
 
 -- | A class or interface type consists of a type declaration specifier,
 --   optionally followed by type arguments (in which case it is a parameterized type).
 data ClassType a
     = ClassType a [(Ident a, [TypeArgument a])]
-  deriving (Eq,Show,Read,Typeable,Generic,Data)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
 
 -- | Type arguments may be either reference types or wildcards.
 data TypeArgument a
     = Wildcard a (Maybe (WildcardBound a))
     | ActualType a (RefType a)
-  deriving (Eq,Show,Read,Typeable,Generic,Data)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
 
 data TypeDeclSpecifier a
     = TypeDeclSpecifier (ClassType a) a
     | TypeDeclSpecifierWithDiamond (ClassType a) (Ident a) (Diamond a) a
     | TypeDeclSpecifierUnqualifiedWithDiamond (Ident a) (Diamond a) a
-  deriving (Eq,Show,Read,Typeable,Generic,Data)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
 
 data Diamond a = Diamond a
-  deriving (Eq,Show,Read,Typeable,Generic,Data)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
 
 -- | Wildcards may be given explicit bounds, either upper (@extends@) or lower (@super@) bounds.
 data WildcardBound a
     = ExtendsBound a (RefType a)
     | SuperBound a (RefType a)
-  deriving (Eq,Show,Read,Typeable,Generic,Data)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
 
 -- | A primitive type is predefined by the Java programming language and named by its reserved keyword.
 data PrimType a
@@ -57,21 +57,21 @@ data PrimType a
     | CharT a
     | FloatT a
     | DoubleT a
-  deriving (Eq,Show,Read,Typeable,Generic,Data)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
 
 
 -- | A class is generic if it declares one or more type variables. These type variables are known
 --   as the type parameters of the class.
 data TypeParam a = TypeParam (Ident a) [RefType a] a
-  deriving (Eq,Show,Read,Typeable,Generic,Data)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
 
 -----------------------------------------------------------------------
 -- Names and identifiers
 
 -- | A single identifier.
 data Ident a = Ident String a
-    deriving (Eq,Ord,Show,Read,Typeable,Generic,Data)
+    deriving (Eq,Ord,Show,Read,Typeable,Generic,Data, Functor)
 
 -- | A name, i.e. a period-separated list of identifiers.
 data Name a = Name [Ident a] a
-    deriving (Eq,Ord,Show,Read,Typeable,Generic,Data)
+    deriving (Eq,Ord,Show,Read,Typeable,Generic,Data, Functor)

--- a/Language/Java/Syntax/Types.hs
+++ b/Language/Java/Syntax/Types.hs
@@ -5,73 +5,73 @@ import Data.Data
 import GHC.Generics (Generic)
 
 -- | There are two kinds of types in the Java programming language: primitive types and reference types.
-data Type
-    = PrimType PrimType
-    | RefType RefType
+data Type a
+    = PrimType (PrimType a) a
+    | RefType (RefType a) a
   deriving (Eq,Show,Read,Typeable,Generic,Data)
 
 -- | There are three kinds of reference types: class types, interface types, and array types.
 --   Reference types may be parameterized with type arguments.
 --   Type variables cannot be syntactically distinguished from class type identifiers,
 --   and are thus represented uniformly as single ident class types.
-data RefType
-    = ClassRefType ClassType
+data RefType a
+    = ClassRefType (ClassType a) a
     {- | TypeVariable Ident -}
-    | ArrayType Type
+    | ArrayType (Type a) a
   deriving (Eq,Show,Read,Typeable,Generic,Data)
 
 -- | A class or interface type consists of a type declaration specifier,
 --   optionally followed by type arguments (in which case it is a parameterized type).
-data ClassType
-    = ClassType [(Ident, [TypeArgument])]
+data ClassType a
+    = ClassType [(Ident a, [TypeArgument a])] a
   deriving (Eq,Show,Read,Typeable,Generic,Data)
 
 -- | Type arguments may be either reference types or wildcards.
-data TypeArgument
-    = Wildcard (Maybe WildcardBound)
-    | ActualType RefType
+data TypeArgument a
+    = Wildcard (Maybe (WildcardBound a)) a
+    | ActualType (RefType a) a
   deriving (Eq,Show,Read,Typeable,Generic,Data)
 
-data TypeDeclSpecifier
-    = TypeDeclSpecifier ClassType
-    | TypeDeclSpecifierWithDiamond ClassType Ident Diamond
-    | TypeDeclSpecifierUnqualifiedWithDiamond Ident Diamond
+data TypeDeclSpecifier a
+    = TypeDeclSpecifier (ClassType a) a
+    | TypeDeclSpecifierWithDiamond (ClassType a) (Ident a) (Diamond a) a
+    | TypeDeclSpecifierUnqualifiedWithDiamond (Ident a) (Diamond a) a
   deriving (Eq,Show,Read,Typeable,Generic,Data)
 
-data Diamond = Diamond
+data Diamond a = Diamond a
   deriving (Eq,Show,Read,Typeable,Generic,Data)
 
 -- | Wildcards may be given explicit bounds, either upper (@extends@) or lower (@super@) bounds.
-data WildcardBound
-    = ExtendsBound RefType
-    | SuperBound RefType
+data WildcardBound a
+    = ExtendsBound (RefType a) a
+    | SuperBound (RefType a) a
   deriving (Eq,Show,Read,Typeable,Generic,Data)
 
 -- | A primitive type is predefined by the Java programming language and named by its reserved keyword.
-data PrimType
-    = BooleanT
-    | ByteT
-    | ShortT
-    | IntT
-    | LongT
-    | CharT
-    | FloatT
-    | DoubleT
+data PrimType a
+    = BooleanT a
+    | ByteT a
+    | ShortT a
+    | IntT a
+    | LongT a
+    | CharT a
+    | FloatT a
+    | DoubleT a
   deriving (Eq,Show,Read,Typeable,Generic,Data)
 
 
 -- | A class is generic if it declares one or more type variables. These type variables are known
 --   as the type parameters of the class.
-data TypeParam = TypeParam Ident [RefType]
+data TypeParam a = TypeParam (Ident a) [RefType a] a
   deriving (Eq,Show,Read,Typeable,Generic,Data)
 
 -----------------------------------------------------------------------
 -- Names and identifiers
 
 -- | A single identifier.
-data Ident = Ident String
+data Ident a = Ident String a
     deriving (Eq,Ord,Show,Read,Typeable,Generic,Data)
 
 -- | A name, i.e. a period-separated list of identifiers.
-data Name = Name [Ident]
+data Name a = Name [Ident a] a
     deriving (Eq,Ord,Show,Read,Typeable,Generic,Data)

--- a/Language/Java/Syntax/Types.hs
+++ b/Language/Java/Syntax/Types.hs
@@ -28,8 +28,8 @@ data ClassType a
 
 -- | Type arguments may be either reference types or wildcards.
 data TypeArgument a
-    = Wildcard (Maybe (WildcardBound a)) a
-    | ActualType (RefType a) a
+    = Wildcard a (Maybe (WildcardBound a))
+    | ActualType a (RefType a)
   deriving (Eq,Show,Read,Typeable,Generic,Data)
 
 data TypeDeclSpecifier a

--- a/Language/Java/Syntax/Types.hs
+++ b/Language/Java/Syntax/Types.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE DeriveDataTypeable, DeriveGeneric, DeriveFunctor #-}
+{-# LANGUAGE DeriveDataTypeable, DeriveGeneric, DeriveFunctor, DeriveFoldable, DeriveTraversable #-}
 module Language.Java.Syntax.Types where
 
 import Data.Data
@@ -8,7 +8,7 @@ import GHC.Generics (Generic)
 data Type a
     = PrimType (PrimType a) a
     | RefType (RefType a) a
-  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor, Foldable, Traversable)
 
 -- | There are three kinds of reference types: class types, interface types, and array types.
 --   Reference types may be parameterized with type arguments.
@@ -18,34 +18,34 @@ data RefType a
     = ClassRefType (ClassType a) a
     {- | TypeVariable Ident -}
     | ArrayType (Type a) a
-  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor, Foldable, Traversable)
 
 -- | A class or interface type consists of a type declaration specifier,
 --   optionally followed by type arguments (in which case it is a parameterized type).
 data ClassType a
     = ClassType a [(Ident a, [TypeArgument a])]
-  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor, Foldable, Traversable)
 
 -- | Type arguments may be either reference types or wildcards.
 data TypeArgument a
     = Wildcard a (Maybe (WildcardBound a))
     | ActualType a (RefType a)
-  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor, Foldable, Traversable)
 
 data TypeDeclSpecifier a
     = TypeDeclSpecifier (ClassType a) a
     | TypeDeclSpecifierWithDiamond (ClassType a) (Ident a) (Diamond a) a
     | TypeDeclSpecifierUnqualifiedWithDiamond (Ident a) (Diamond a) a
-  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor, Foldable, Traversable)
 
 data Diamond a = Diamond a
-  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor, Foldable, Traversable)
 
 -- | Wildcards may be given explicit bounds, either upper (@extends@) or lower (@super@) bounds.
 data WildcardBound a
     = ExtendsBound a (RefType a)
     | SuperBound a (RefType a)
-  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor, Foldable, Traversable)
 
 -- | A primitive type is predefined by the Java programming language and named by its reserved keyword.
 data PrimType a
@@ -57,21 +57,21 @@ data PrimType a
     | CharT a
     | FloatT a
     | DoubleT a
-  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor, Foldable, Traversable)
 
 
 -- | A class is generic if it declares one or more type variables. These type variables are known
 --   as the type parameters of the class.
 data TypeParam a = TypeParam (Ident a) [RefType a] a
-  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor)
+  deriving (Eq,Show,Read,Typeable,Generic,Data, Functor, Foldable, Traversable)
 
 -----------------------------------------------------------------------
 -- Names and identifiers
 
 -- | A single identifier.
 data Ident a = Ident String a
-    deriving (Eq,Ord,Show,Read,Typeable,Generic,Data, Functor)
+    deriving (Eq,Ord,Show,Read,Typeable,Generic,Data, Functor, Foldable, Traversable)
 
 -- | A name, i.e. a period-separated list of identifiers.
 data Name a = Name [Ident a] a
-    deriving (Eq,Ord,Show,Read,Typeable,Generic,Data, Functor)
+    deriving (Eq,Ord,Show,Read,Typeable,Generic,Data, Functor, Foldable, Traversable)

--- a/language-java.cabal
+++ b/language-java.cabal
@@ -27,6 +27,7 @@ Library
                       , array >= 0.1
                       , pretty >= 1.0
                       , parsec >= 3.0
+                      , extra >= 1.7
 
   if impl(ghc < 7.6)
     Build-Depends:      syb

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,18 @@
+let
+  nixpkgsPin = {
+    url = https://github.com/NixOS/nixpkgs/archive/c95bf18beba4290af25c60cbaaceea1110d0f727.tar.gz;
+  };
+  pkgs = import (builtins.fetchTarball nixpkgsPin) {};
+in
+
+pkgs.stdenv.mkDerivation rec {
+  name = "language-java";
+  src = ./.;
+  nativeBuildInputs = with pkgs; with haskellPackages; [
+  ];
+  buildInputs = with pkgs; with haskellPackages; [
+    haskell.compiler.ghc8107
+    cabal-install
+    hlint
+  ];
+}


### PR DESCRIPTION
Adds SourceInfo as a param to all the AST types and to the parser output. This is a rough hacked out attempt but should be enough for printing out reasonable context spans.

```
data SourceInfo = SourceSpan SourcePos SourcePos
                | SourceSpot SourcePos
                | InaccSpot SourcePos
  deriving Show
```

`InaccSpot` shouldn't be trusted and are placeholders until I can figure them out some more.

TODO:
- Fix up InAccSpots (Figure out the foldl locations)
- Limit SourceSpot to single token AST types
- Move info param in AST data types to the end
- Use withSourceSpan in missing spots
- Check that no parsing semantics have changed
- Squash

Kludge caveats:
- I've had to push Show constraints on the pretty printer.
- Test suite is still a huge question